### PR TITLE
Add inventory reorder business rule to modernized .NET 8 catalog

### DIFF
--- a/eShopModernized/src/eShopCoreModernized/Domain/IInventoryReorderPolicy.cs
+++ b/eShopModernized/src/eShopCoreModernized/Domain/IInventoryReorderPolicy.cs
@@ -1,0 +1,14 @@
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Domain
+{
+    /// <summary>
+    /// Encapsulates the business rule that decides whether a catalog item needs
+    /// to be reordered. Kept out of the UI and data-access layers so the rule is
+    /// testable and documented in one place.
+    /// </summary>
+    public interface IInventoryReorderPolicy
+    {
+        bool RequiresReorder(CatalogItem item);
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Domain/InventoryReorderPolicy.cs
+++ b/eShopModernized/src/eShopCoreModernized/Domain/InventoryReorderPolicy.cs
@@ -1,0 +1,23 @@
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Domain
+{
+    /// <summary>
+    /// An item needs reordering when its available stock has dropped to or below
+    /// its restock threshold and a reorder is not already in progress.
+    /// </summary>
+    public class InventoryReorderPolicy : IInventoryReorderPolicy
+    {
+        public bool RequiresReorder(CatalogItem item)
+        {
+            ArgumentNullException.ThrowIfNull(item);
+
+            if (item.OnReorder)
+            {
+                return false;
+            }
+
+            return item.AvailableStock <= item.RestockThreshold;
+        }
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Program.cs
+++ b/eShopModernized/src/eShopCoreModernized/Program.cs
@@ -1,6 +1,7 @@
 using eShopCoreModernized.Models;
 using eShopCoreModernized.Services;
 using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Domain;
 using eShopCoreModernized.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Azure.Storage.Blobs;
@@ -69,6 +70,8 @@ else
 }
 
 builder.Services.AddSingleton<CatalogItemHiLoGenerator>();
+
+builder.Services.AddSingleton<IInventoryReorderPolicy, InventoryReorderPolicy>();
 
 if (catalogConfig.UseAzureActiveDirectory)
 {

--- a/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
@@ -30,11 +30,11 @@ namespace eShopCoreModernized.Services
 
             catalogItems = new List<CatalogItem>
             {
-                new CatalogItem { Id = 1, Name = ".NET Bot Black Hoodie", Description = ".NET Bot Black Hoodie", Price = 19.5M, PictureFileName = "1.png", CatalogTypeId = 2, CatalogBrandId = 2, AvailableStock = 100, RestockThreshold = 0, MaxStockThreshold = 0, OnReorder = false },
-                new CatalogItem { Id = 2, Name = ".NET Black & White Mug", Description = ".NET Black & White Mug", Price = 8.50M, PictureFileName = "2.png", CatalogTypeId = 1, CatalogBrandId = 2, AvailableStock = 100, RestockThreshold = 0, MaxStockThreshold = 0, OnReorder = false },
-                new CatalogItem { Id = 3, Name = "Prism White T-Shirt", Description = "Prism White T-Shirt", Price = 12M, PictureFileName = "3.png", CatalogTypeId = 2, CatalogBrandId = 5, AvailableStock = 100, RestockThreshold = 0, MaxStockThreshold = 0, OnReorder = false },
-                new CatalogItem { Id = 4, Name = ".NET Foundation T-shirt", Description = ".NET Foundation T-shirt", Price = 12M, PictureFileName = "4.png", CatalogTypeId = 2, CatalogBrandId = 2, AvailableStock = 100, RestockThreshold = 0, MaxStockThreshold = 0, OnReorder = false },
-                new CatalogItem { Id = 5, Name = "Roslyn Red Sheet", Description = "Roslyn Red Sheet", Price = 8.5M, PictureFileName = "5.png", CatalogTypeId = 3, CatalogBrandId = 2, AvailableStock = 100, RestockThreshold = 0, MaxStockThreshold = 0, OnReorder = false }
+                new CatalogItem { Id = 1, Name = ".NET Bot Black Hoodie", Description = ".NET Bot Black Hoodie", Price = 19.5M, PictureFileName = "1.png", CatalogTypeId = 2, CatalogBrandId = 2, AvailableStock = 100, RestockThreshold = 20, MaxStockThreshold = 200, OnReorder = false },
+                new CatalogItem { Id = 2, Name = ".NET Black & White Mug", Description = ".NET Black & White Mug", Price = 8.50M, PictureFileName = "2.png", CatalogTypeId = 1, CatalogBrandId = 2, AvailableStock = 8, RestockThreshold = 15, MaxStockThreshold = 200, OnReorder = false },
+                new CatalogItem { Id = 3, Name = "Prism White T-Shirt", Description = "Prism White T-Shirt", Price = 12M, PictureFileName = "3.png", CatalogTypeId = 2, CatalogBrandId = 5, AvailableStock = 100, RestockThreshold = 20, MaxStockThreshold = 200, OnReorder = false },
+                new CatalogItem { Id = 4, Name = ".NET Foundation T-shirt", Description = ".NET Foundation T-shirt", Price = 12M, PictureFileName = "4.png", CatalogTypeId = 2, CatalogBrandId = 2, AvailableStock = 3, RestockThreshold = 10, MaxStockThreshold = 200, OnReorder = true },
+                new CatalogItem { Id = 5, Name = "Roslyn Red Sheet", Description = "Roslyn Red Sheet", Price = 8.5M, PictureFileName = "5.png", CatalogTypeId = 3, CatalogBrandId = 2, AvailableStock = 0, RestockThreshold = 10, MaxStockThreshold = 200, OnReorder = false }
             };
 
             foreach (var item in catalogItems)

--- a/eShopModernized/src/eShopCoreModernized/Views/Catalog/CatalogTable.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Catalog/CatalogTable.cshtml
@@ -1,4 +1,5 @@
 @model IEnumerable<eShopCoreModernized.Models.CatalogItem>
+@inject eShopCoreModernized.Domain.IInventoryReorderPolicy ReorderPolicy
 
 <table class="table">
     <thead>
@@ -31,6 +32,9 @@
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.MaxStockThreshold)
+            </th>
+            <th>
+                Reorder
             </th>
             <th></th>
         </tr>
@@ -68,6 +72,20 @@
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.MaxStockThreshold)
+                </td>
+                <td>
+                    @if (ReorderPolicy.RequiresReorder(item))
+                    {
+                        <span class="badge badge-danger" style="background-color:#c8102e;color:#fff;padding:4px 8px;border-radius:4px;">Reorder needed</span>
+                    }
+                    else if (item.OnReorder)
+                    {
+                        <span class="badge badge-info" style="background-color:#0072c6;color:#fff;padding:4px 8px;border-radius:4px;">On order</span>
+                    }
+                    else
+                    {
+                        <span class="badge badge-success" style="background-color:#5cb85c;color:#fff;padding:4px 8px;border-radius:4px;">In stock</span>
+                    }
                 </td>
                 <td>
                     @Html.ActionLink("Edit", "Edit", new { id = item.Id }, new { @class = "esh-table-link" }) |

--- a/eShopModernized/tests/eShopCoreModernized.Tests/InventoryReorderPolicyTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/InventoryReorderPolicyTests.cs
@@ -1,0 +1,50 @@
+using eShopCoreModernized.Domain;
+using eShopCoreModernized.Models;
+using Xunit;
+
+namespace eShopCoreModernized.Tests
+{
+    public class InventoryReorderPolicyTests
+    {
+        private readonly InventoryReorderPolicy _policy = new();
+
+        private static CatalogItem Item(int stock, int restock, bool onReorder = false) =>
+            new() { AvailableStock = stock, RestockThreshold = restock, OnReorder = onReorder };
+
+        [Fact]
+        public void RequiresReorder_WhenStockBelowThreshold_ReturnsTrue()
+        {
+            Assert.True(_policy.RequiresReorder(Item(stock: 8, restock: 15)));
+        }
+
+        [Fact]
+        public void RequiresReorder_WhenStockEqualsThreshold_ReturnsTrue()
+        {
+            Assert.True(_policy.RequiresReorder(Item(stock: 15, restock: 15)));
+        }
+
+        [Fact]
+        public void RequiresReorder_WhenStockAboveThreshold_ReturnsFalse()
+        {
+            Assert.False(_policy.RequiresReorder(Item(stock: 100, restock: 20)));
+        }
+
+        [Fact]
+        public void RequiresReorder_WhenAlreadyOnReorder_ReturnsFalse()
+        {
+            Assert.False(_policy.RequiresReorder(Item(stock: 3, restock: 10, onReorder: true)));
+        }
+
+        [Fact]
+        public void RequiresReorder_WhenStockZero_ReturnsTrue()
+        {
+            Assert.True(_policy.RequiresReorder(Item(stock: 0, restock: 10)));
+        }
+
+        [Fact]
+        public void RequiresReorder_NullItem_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => _policy.RequiresReorder(null!));
+        }
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\eShopCoreModernized\eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Demo of a small, end-to-end **legacy-modernization** change on the modernized .NET 8 eShop app (`eShopModernized/src/eShopCoreModernized`): take a *threshold/business rule* that would typically be buried in UI code or a stored proc and re-home it in a clean, documented, **unit-tested domain layer**, then surface its result in the catalog UI.

The rule (an inventory analogue of a pass/fail inspection rule):

```csharp
// Domain/InventoryReorderPolicy.cs
RequiresReorder(item) =>
    !item.OnReorder && item.AvailableStock <= item.RestockThreshold;
```

What changed:
- **New `Domain/IInventoryReorderPolicy` + `InventoryReorderPolicy`** — the rule lives in one place, isolated from the UI and data-access layers. Registered in DI in `Program.cs`.
- **`Views/Catalog/CatalogTable.cshtml`** — adds a `Reorder` column that `@inject`s the policy and renders a badge per row: `Reorder needed` (red) / `On order` (blue) / `In stock` (green). The view calls the policy rather than embedding the rule inline.
- **`Services/CatalogServiceMock.cs`** — seed data given realistic stock/restock values (previously all `RestockThreshold = 0`) so the three states are visible at a glance.
- **New xUnit project `eShopModernized/tests/eShopCoreModernized.Tests`** — 6 tests covering the rule's boundaries (below / equal / above threshold, already-on-reorder, zero stock, null guard).

### Verify
- Tests: `dotnet test eShopModernized/tests/eShopCoreModernized.Tests` → **6 passed**.
- Run: `dotnet run --project eShopModernized/src/eShopCoreModernized` (defaults to `UseMockData: true`, no SQL Server needed) and open `/Catalog/Index`.

Screenshot of the running .NET 8 app:

![Catalog with reorder badges](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctN2JmN2JlZjM3ODQ5NDllZmFkZGM3YjQ5NzRmYzQ1YjYiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctN2JmN2JlZjM3ODQ5NDllZmFkZGM3YjQ5NzRmYzQ1YjYvOWEzOWZiNGUtYjg0My00YmVhLWFjZDgtZGYzZDNmMWVjOTYxIiwiaWF0IjoxNzgyNzMyMTgzLCJleHAiOjE3ODMzMzY5ODMsImZpbGVuYW1lIjoic3NfN2NlYzg4NzkucG5nIn0.HBU5W32F6yNxUidbM3NVfGurJGoNTZM4GtSE5G2dM6g)

### Why this matters for the modernization story
This is a micro-example of the core legacy-modernization task: recovering an undocumented business rule and relocating it into a separable, testable layer (instead of leaving it inside a fat-client form or a stored procedure), with regression tests that lock in the behavior.


Link to Devin session: https://app.devin.ai/sessions/25e51475761346cb94c53d75545a49cb
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/30?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->