### PR TITLE
Add unit tests for eShopModernized (.NET 8) app

### DIFF
--- a/eShopModernized/tests/eShopCoreModernized.Tests/CatalogConfigurationTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/CatalogConfigurationTests.cs
@@ -1,0 +1,152 @@
+using eShopCoreModernized.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace eShopCoreModernized.Tests;
+
+public class CatalogConfigurationTests
+{
+    private static CatalogConfiguration CreateConfig(Dictionary<string, string?> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        return new CatalogConfiguration(configuration);
+    }
+
+    [Fact]
+    public void UseMockData_ReturnsTrue_WhenSet()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "AppSettings:UseMockData", "true" }
+        });
+
+        Assert.True(config.UseMockData);
+    }
+
+    [Fact]
+    public void UseMockData_ReturnsFalse_WhenNotSet()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>());
+
+        Assert.False(config.UseMockData);
+    }
+
+    [Fact]
+    public void UseAzureStorage_ReadsFromConfig()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "AppSettings:UseAzureStorage", "true" }
+        });
+
+        Assert.True(config.UseAzureStorage);
+    }
+
+    [Fact]
+    public void UseManagedIdentity_ReadsFromConfig()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "AppSettings:UseAzureManagedIdentity", "true" }
+        });
+
+        Assert.True(config.UseManagedIdentity);
+    }
+
+    [Fact]
+    public void UseCustomizationData_ReadsFromConfig()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "AppSettings:UseCustomizationData", "true" }
+        });
+
+        Assert.True(config.UseCustomizationData);
+    }
+
+    [Fact]
+    public void UseAzureActiveDirectory_ReadsFromConfig()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "AppSettings:UseAzureActiveDirectory", "true" }
+        });
+
+        Assert.True(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void StorageConnectionString_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:StorageConnectionString", "DefaultEndpointsProtocol=https;AccountName=test" }
+        });
+
+        Assert.Equal("DefaultEndpointsProtocol=https;AccountName=test", config.StorageConnectionString);
+    }
+
+    [Fact]
+    public void StorageConnectionString_ReturnsEmpty_WhenNotSet()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>());
+
+        Assert.Equal(string.Empty, config.StorageConnectionString);
+    }
+
+    [Fact]
+    public void AppInsightsInstrumentationKey_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:ApplicationInsights:InstrumentationKey", "test-key" }
+        });
+
+        Assert.Equal("test-key", config.AppInsightsInstrumentationKey);
+    }
+
+    [Fact]
+    public void AppInsightsConnectionString_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:ApplicationInsights:ConnectionString", "InstrumentationKey=abc" }
+        });
+
+        Assert.Equal("InstrumentationKey=abc", config.AppInsightsConnectionString);
+    }
+
+    [Fact]
+    public void AzureActiveDirectoryClientId_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:ActiveDirectory:ClientId", "client-123" }
+        });
+
+        Assert.Equal("client-123", config.AzureActiveDirectoryClientId);
+    }
+
+    [Fact]
+    public void AzureActiveDirectoryTenant_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:ActiveDirectory:TenantId", "tenant-456" }
+        });
+
+        Assert.Equal("tenant-456", config.AzureActiveDirectoryTenant);
+    }
+
+    [Fact]
+    public void PostLogoutRedirectUri_ReturnsValue()
+    {
+        var config = CreateConfig(new Dictionary<string, string?>
+        {
+            { "Azure:ActiveDirectory:PostLogoutRedirectUri", "https://example.com/signout" }
+        });
+
+        Assert.Equal("https://example.com/signout", config.PostLogoutRedirectUri);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/CatalogItemTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/CatalogItemTests.cs
@@ -1,0 +1,67 @@
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Tests;
+
+public class CatalogItemTests
+{
+    [Fact]
+    public void DefaultConstructor_SetsPictureFileName()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(CatalogItem.DefaultPictureName, item.PictureFileName);
+    }
+
+    [Fact]
+    public void DefaultPictureName_IsDummyPng()
+    {
+        Assert.Equal("dummy.png", CatalogItem.DefaultPictureName);
+    }
+
+    [Fact]
+    public void Properties_CanBeSetAndRead()
+    {
+        var item = new CatalogItem
+        {
+            Id = 42,
+            Name = "Test Item",
+            Description = "A test description",
+            Price = 19.99M,
+            PictureFileName = "test.png",
+            PictureUri = "http://example.com/test.png",
+            TempImageName = "temp.png",
+            CatalogTypeId = 1,
+            CatalogBrandId = 2,
+            AvailableStock = 100,
+            RestockThreshold = 10,
+            MaxStockThreshold = 500,
+            OnReorder = true
+        };
+
+        Assert.Equal(42, item.Id);
+        Assert.Equal("Test Item", item.Name);
+        Assert.Equal("A test description", item.Description);
+        Assert.Equal(19.99M, item.Price);
+        Assert.Equal("test.png", item.PictureFileName);
+        Assert.Equal("http://example.com/test.png", item.PictureUri);
+        Assert.Equal("temp.png", item.TempImageName);
+        Assert.Equal(1, item.CatalogTypeId);
+        Assert.Equal(2, item.CatalogBrandId);
+        Assert.Equal(100, item.AvailableStock);
+        Assert.Equal(10, item.RestockThreshold);
+        Assert.Equal(500, item.MaxStockThreshold);
+        Assert.True(item.OnReorder);
+    }
+
+    [Fact]
+    public void NavigationProperties_DefaultToNull()
+    {
+        var item = new CatalogItem();
+
+        Assert.Null(item.CatalogType);
+        Assert.Null(item.CatalogBrand);
+        Assert.Null(item.Description);
+        Assert.Null(item.PictureUri);
+        Assert.Null(item.TempImageName);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/CatalogServiceMockTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/CatalogServiceMockTests.cs
@@ -1,0 +1,204 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+
+namespace eShopCoreModernized.Tests;
+
+public class CatalogServiceMockTests
+{
+    private readonly CatalogServiceMock _service;
+
+    public CatalogServiceMockTests()
+    {
+        _service = new CatalogServiceMock();
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsCorrectPage()
+    {
+        var result = _service.GetCatalogItemsPaginated(2, 0);
+
+        Assert.Equal(2, result.Data.Count());
+        Assert.Equal(0, result.ActualPage);
+        Assert.Equal(2, result.ItemsPerPage);
+        Assert.Equal(5, result.TotalItems);
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_SecondPage()
+    {
+        var result = _service.GetCatalogItemsPaginated(2, 1);
+
+        Assert.Equal(2, result.Data.Count());
+        Assert.Equal(1, result.ActualPage);
+    }
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_DelegatesToSync()
+    {
+        var result = await _service.GetCatalogItemsPaginatedAsync(3, 0);
+
+        Assert.Equal(3, result.Data.Count());
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsItem_WhenExists()
+    {
+        var item = _service.FindCatalogItem(1);
+
+        Assert.NotNull(item);
+        Assert.Equal(1, item.Id);
+        Assert.Equal(".NET Bot Black Hoodie", item.Name);
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsNull_WhenNotFound()
+    {
+        var item = _service.FindCatalogItem(999);
+
+        Assert.Null(item);
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ReturnsItem()
+    {
+        var item = await _service.FindCatalogItemAsync(2);
+
+        Assert.NotNull(item);
+        Assert.Equal(2, item.Id);
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsMockTypes()
+    {
+        var types = _service.GetCatalogTypes();
+
+        Assert.Equal(4, types.Count());
+        Assert.Contains(types, t => t.Type == "Mug");
+        Assert.Contains(types, t => t.Type == "T-Shirt");
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsMockTypes()
+    {
+        var types = await _service.GetCatalogTypesAsync();
+
+        Assert.Equal(4, types.Count());
+    }
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsMockBrands()
+    {
+        var brands = _service.GetCatalogBrands();
+
+        Assert.Equal(5, brands.Count());
+        Assert.Contains(brands, b => b.Brand == "Azure");
+        Assert.Contains(brands, b => b.Brand == ".NET");
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsMockBrands()
+    {
+        var brands = await _service.GetCatalogBrandsAsync();
+
+        Assert.Equal(5, brands.Count());
+    }
+
+    [Fact]
+    public void CreateCatalogItem_AddsItemWithNextId()
+    {
+        var newItem = new CatalogItem { Name = "New Item", Price = 10M };
+
+        _service.CreateCatalogItem(newItem);
+
+        Assert.Equal(6, newItem.Id);
+        var found = _service.FindCatalogItem(6);
+        Assert.NotNull(found);
+        Assert.Equal("New Item", found.Name);
+    }
+
+    [Fact]
+    public async Task CreateCatalogItemAsync_AddsItem()
+    {
+        var newItem = new CatalogItem { Name = "Async Item", Price = 5M };
+
+        await _service.CreateCatalogItemAsync(newItem);
+
+        var found = _service.FindCatalogItem(newItem.Id);
+        Assert.NotNull(found);
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_ReplacesExistingItem()
+    {
+        var updated = new CatalogItem { Id = 1, Name = "Updated Name", Price = 99M };
+
+        _service.UpdateCatalogItem(updated);
+
+        var found = _service.FindCatalogItem(1);
+        Assert.NotNull(found);
+        Assert.Equal("Updated Name", found.Name);
+        Assert.Equal(99M, found.Price);
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_NoOp_WhenItemNotFound()
+    {
+        var nonExistent = new CatalogItem { Id = 999, Name = "Ghost" };
+
+        _service.UpdateCatalogItem(nonExistent);
+
+        Assert.Null(_service.FindCatalogItem(999));
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_ReplacesItem()
+    {
+        var updated = new CatalogItem { Id = 2, Name = "Async Updated", Price = 50M };
+
+        await _service.UpdateCatalogItemAsync(updated);
+
+        var found = _service.FindCatalogItem(2);
+        Assert.NotNull(found);
+        Assert.Equal("Async Updated", found.Name);
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_RemovesExistingItem()
+    {
+        var item = _service.FindCatalogItem(1)!;
+
+        _service.RemoveCatalogItem(item);
+
+        Assert.Null(_service.FindCatalogItem(1));
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_RemovesItem()
+    {
+        var item = (await _service.FindCatalogItemAsync(3))!;
+
+        await _service.RemoveCatalogItemAsync(item);
+
+        Assert.Null(_service.FindCatalogItem(3));
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var exception = Record.Exception(() => _service.Dispose());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Constructor_AssignsBrandsAndTypesToItems()
+    {
+        var item = _service.FindCatalogItem(1);
+
+        Assert.NotNull(item);
+        Assert.NotNull(item.CatalogBrand);
+        Assert.Equal(".NET", item.CatalogBrand.Brand);
+        Assert.NotNull(item.CatalogType);
+        Assert.Equal("T-Shirt", item.CatalogType.Type);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/ImageMockStorageTests.cs
@@ -1,0 +1,86 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopCoreModernized.Tests;
+
+public class ImageMockStorageTests
+{
+    private readonly ImageMockStorage _storage;
+
+    public ImageMockStorageTests()
+    {
+        var env = new Mock<IWebHostEnvironment>();
+        env.Setup(e => e.WebRootPath).Returns("/wwwroot");
+        var logger = new Mock<ILogger<ImageMockStorage>>();
+        _storage = new ImageMockStorage(env.Object, logger.Object);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsPicsPath()
+    {
+        Assert.Equal("/pics/", _storage.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPng()
+    {
+        Assert.Equal("/pics/default.png", _storage.UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsCorrectPath()
+    {
+        var item = new CatalogItem { Id = 5, PictureFileName = "test.png" };
+
+        var url = _storage.BuildUrlImage(item);
+
+        Assert.Equal("/pics/5/test.png", url);
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsDefault_WhenPictureFileNameIsEmpty()
+    {
+        var item = new CatalogItem { Id = 1, PictureFileName = "" };
+
+        var url = _storage.BuildUrlImage(item);
+
+        Assert.Equal("/pics/default.png", url);
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CompletesSuccessfully()
+    {
+        await _storage.InitializeCatalogImagesAsync();
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CompletesSuccessfully()
+    {
+        var item = new CatalogItem { Id = 1 };
+
+        await _storage.UpdateImageAsync(item);
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_ReturnsMockUrl()
+    {
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.FileName).Returns("photo.jpg");
+
+        var result = await _storage.UploadTempImageAsync(fileMock.Object, 7);
+
+        Assert.Equal("/pics/temp/photo.jpg", result);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var exception = Record.Exception(() => _storage.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/MigrationTelemetryInitializerTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/MigrationTelemetryInitializerTests.cs
@@ -1,0 +1,20 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace eShopCoreModernized.Tests;
+
+public class MigrationTelemetryInitializerTests
+{
+    [Fact]
+    public void Initialize_SetsExpectedGlobalProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new RequestTelemetry();
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(".NET Core 6.0", telemetry.Context.GlobalProperties["ApplicationVersion"]);
+        Assert.Equal("StranglerFig-Complete", telemetry.Context.GlobalProperties["MigrationPhase"]);
+        Assert.Equal("Catalog-Core", telemetry.Context.GlobalProperties["ServiceType"]);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,52 @@
+using eShopCoreModernized.ViewModel;
+
+namespace eShopCoreModernized.Tests;
+
+public class PaginatedItemsViewModelTests
+{
+    [Fact]
+    public void Constructor_SetsPropertiesCorrectly()
+    {
+        var data = new List<string> { "a", "b", "c" };
+
+        var vm = new PaginatedItemsViewModel<string>(2, 10, 50, data);
+
+        Assert.Equal(2, vm.ActualPage);
+        Assert.Equal(10, vm.ItemsPerPage);
+        Assert.Equal(50, vm.TotalItems);
+        Assert.Equal(data, vm.Data);
+    }
+
+    [Fact]
+    public void TotalPages_CalculatedCorrectly_ExactDivision()
+    {
+        var vm = new PaginatedItemsViewModel<string>(0, 10, 30, Array.Empty<string>());
+
+        Assert.Equal(3, vm.TotalPages);
+    }
+
+    [Fact]
+    public void TotalPages_RoundsUp_WhenNotExactDivision()
+    {
+        var vm = new PaginatedItemsViewModel<string>(0, 10, 25, Array.Empty<string>());
+
+        Assert.Equal(3, vm.TotalPages);
+    }
+
+    [Fact]
+    public void TotalPages_IsOne_WhenSinglePage()
+    {
+        var vm = new PaginatedItemsViewModel<string>(0, 10, 5, Array.Empty<string>());
+
+        Assert.Equal(1, vm.TotalPages);
+    }
+
+    [Fact]
+    public void TotalPages_IsSettable()
+    {
+        var vm = new PaginatedItemsViewModel<string>(0, 10, 100, Array.Empty<string>());
+        vm.TotalPages = 42;
+
+        Assert.Equal(42, vm.TotalPages);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/eShopCoreModernized/eShopModernized.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a new xUnit test project (`eShopCoreModernized.Tests`) for the most modern app in the repo — the .NET 8 `eShopModernized` project — which previously had **zero test coverage**.

### Test framework setup
- xUnit + Moq + coverlet (msbuild) + EF Core InMemory provider
- `eShopCoreModernized.Tests.csproj` references the main `eShopModernized.csproj`

### 50 tests across 6 test classes

| Test class | Covers | Key scenarios |
|---|---|---|
| `PaginatedItemsViewModelTests` | `PaginatedItemsViewModel<T>` | Constructor property mapping, `TotalPages` ceiling math, settable `TotalPages` |
| `CatalogServiceMockTests` | `CatalogServiceMock` (all `ICatalogService` methods) | Pagination, find by ID (hit/miss), CRUD (sync + async), brand/type lookups, dispose |
| `CatalogItemTests` | `CatalogItem` model | Default constructor sets `PictureFileName`, all property getters/setters, nullable defaults |
| `ImageMockStorageTests` | `ImageMockStorage` | `BaseUrl()`, `BuildUrlImage()` (normal + empty filename fallback), `UploadTempImageAsync`, dispose |
| `CatalogConfigurationTests` | `CatalogConfiguration` | All 11 config properties via in-memory `IConfiguration`, true/false/missing-key paths |
| `MigrationTelemetryInitializerTests` | `MigrationTelemetryInitializer` | Verifies all 3 global telemetry properties set on `RequestTelemetry` |

### Coverage results

| Metric | Before | After |
|---|---|---|
| Line | 0% | **19.52%** |
| Branch | 0% | **5.41%** |
| Method | 0% | **41.83%** |

Link to Devin session: https://app.devin.ai/sessions/602151e13ec94828bb7405a6e9ca9406
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/31?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->