### PR TITLE
Add xUnit test project and code coverage for eShopCoreModernized

### DIFF
--- a/eShopModernized/eShopModernized.sln
+++ b/eShopModernized/eShopModernized.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{693AA7C0-4B11-4786-A145-4A987D3AD463}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopModernized", "src\eShopCoreModernized\eShopModernized.csproj", "{9168AA5C-6868-49C2-B627-97486F45BAC0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9922E677-2E94-44AE-9CB8-1B505FF323B0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopCoreModernized.Tests", "tests\eShopCoreModernized.Tests\eShopCoreModernized.Tests.csproj", "{B24DFA47-6556-40A2-AF64-500DC2BB3039}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9168AA5C-6868-49C2-B627-97486F45BAC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9168AA5C-6868-49C2-B627-97486F45BAC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9168AA5C-6868-49C2-B627-97486F45BAC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9168AA5C-6868-49C2-B627-97486F45BAC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B24DFA47-6556-40A2-AF64-500DC2BB3039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B24DFA47-6556-40A2-AF64-500DC2BB3039}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B24DFA47-6556-40A2-AF64-500DC2BB3039}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B24DFA47-6556-40A2-AF64-500DC2BB3039}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9168AA5C-6868-49C2-B627-97486F45BAC0} = {693AA7C0-4B11-4786-A145-4A987D3AD463}
+		{B24DFA47-6556-40A2-AF64-500DC2BB3039} = {9922E677-2E94-44AE-9CB8-1B505FF323B0}
+	EndGlobalSection
+EndGlobal

--- a/eShopModernized/tests/README.md
+++ b/eShopModernized/tests/README.md
@@ -1,0 +1,53 @@
+# eShopCoreModernized Tests
+
+Automated unit tests for the .NET 8 `eShopCoreModernized` project, written with
+[xUnit](https://xunit.net/).
+
+## Layout
+
+- `eShopCoreModernized.Tests/` — xUnit test project referencing
+  `../src/eShopCoreModernized/eShopModernized.csproj`.
+
+The test project is included in the solution at
+`eShopModernized/eShopModernized.sln`.
+
+## Prerequisites
+
+- [.NET SDK 8.0](https://dotnet.microsoft.com/download/dotnet/8.0)
+
+## Running the tests
+
+From the `eShopModernized/` directory:
+
+```bash
+dotnet build eShopModernized.sln
+dotnet test eShopModernized.sln
+```
+
+You can also run the test project directly:
+
+```bash
+dotnet test tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
+```
+
+## Collecting code coverage
+
+Coverage is collected with [coverlet](https://github.com/coverlet-coverage/coverlet)
+via the `coverlet.collector` package. From the `eShopModernized/` directory:
+
+```bash
+dotnet test eShopModernized.sln --collect:"XPlat Code Coverage" --results-directory ./TestResults
+```
+
+This produces a Cobertura report at
+`TestResults/<guid>/coverage.cobertura.xml`. The `line-rate` attribute on the
+`<package name="eShopCoreModernized">` element is the line coverage ratio for the
+assembly (e.g. `0.1648` = 16.48%).
+
+To turn the Cobertura XML into a human-readable HTML report, install
+[ReportGenerator](https://github.com/danielpalme/ReportGenerator) and run:
+
+```bash
+dotnet tool install -g dotnet-reportgenerator-globaltool
+reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"TestResults/coverage-report" -reporttypes:Html
+```

--- a/eShopModernized/tests/eShopCoreModernized.Tests/CatalogServiceMockTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/CatalogServiceMockTests.cs
@@ -1,0 +1,205 @@
+using Xunit;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.ViewModel;
+
+namespace eShopCoreModernized.Tests;
+
+public class CatalogServiceMockTests
+{
+    private static CatalogServiceMock CreateService() => new();
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsSeededBrands()
+    {
+        var service = CreateService();
+
+        var brands = service.GetCatalogBrands().ToList();
+
+        Assert.Equal(5, brands.Count);
+        Assert.Contains(brands, b => b.Brand == "Azure");
+        Assert.Contains(brands, b => b.Brand == ".NET");
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsSeededBrands()
+    {
+        var service = CreateService();
+
+        var brands = (await service.GetCatalogBrandsAsync()).ToList();
+
+        Assert.Equal(5, brands.Count);
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsSeededTypes()
+    {
+        var service = CreateService();
+
+        var types = service.GetCatalogTypes().ToList();
+
+        Assert.Equal(4, types.Count);
+        Assert.Contains(types, t => t.Type == "Mug");
+        Assert.Contains(types, t => t.Type == "T-Shirt");
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsSeededTypes()
+    {
+        var service = CreateService();
+
+        var types = (await service.GetCatalogTypesAsync()).ToList();
+
+        Assert.Equal(4, types.Count);
+    }
+
+    [Theory]
+    [InlineData(2, 0, 2)]
+    [InlineData(3, 0, 3)]
+    [InlineData(10, 0, 5)]
+    [InlineData(2, 2, 1)]
+    public void GetCatalogItemsPaginated_ReturnsCorrectPage(int pageSize, int pageIndex, int expectedCount)
+    {
+        var service = CreateService();
+
+        var page = service.GetCatalogItemsPaginated(pageSize, pageIndex);
+
+        Assert.Equal(expectedCount, page.Data.Count());
+        Assert.Equal(pageIndex, page.ActualPage);
+        Assert.Equal(pageSize, page.ItemsPerPage);
+        Assert.Equal(5, page.TotalItems);
+    }
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_MatchesSyncResult()
+    {
+        var service = CreateService();
+
+        var page = await service.GetCatalogItemsPaginatedAsync(2, 1);
+
+        Assert.Equal(2, page.Data.Count());
+        Assert.Equal(1, page.ActualPage);
+        Assert.Equal(5, page.TotalItems);
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsItem_WhenIdExists()
+    {
+        var service = CreateService();
+
+        var item = service.FindCatalogItem(1);
+
+        Assert.NotNull(item);
+        Assert.Equal(1, item!.Id);
+        Assert.Equal(".NET Bot Black Hoodie", item.Name);
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsNull_WhenIdUnknown()
+    {
+        var service = CreateService();
+
+        Assert.Null(service.FindCatalogItem(999));
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ReturnsItem_WhenIdExists()
+    {
+        var service = CreateService();
+
+        var item = await service.FindCatalogItemAsync(2);
+
+        Assert.NotNull(item);
+        Assert.Equal(2, item!.Id);
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ReturnsNull_WhenIdUnknown()
+    {
+        var service = CreateService();
+
+        Assert.Null(await service.FindCatalogItemAsync(-1));
+    }
+
+    [Fact]
+    public void CreateCatalogItem_AssignsMaxPlusOneId_AndAddsItem()
+    {
+        var service = CreateService();
+        var newItem = new CatalogItem { Name = "New Item" };
+
+        service.CreateCatalogItem(newItem);
+
+        Assert.Equal(6, newItem.Id);
+        Assert.Equal(6, service.GetCatalogItemsPaginated(100, 0).TotalItems);
+        Assert.NotNull(service.FindCatalogItem(6));
+    }
+
+    [Fact]
+    public async Task CreateCatalogItemAsync_AddsItem()
+    {
+        var service = CreateService();
+        var newItem = new CatalogItem { Name = "Async Item" };
+
+        await service.CreateCatalogItemAsync(newItem);
+
+        Assert.Equal(6, newItem.Id);
+        Assert.NotNull(await service.FindCatalogItemAsync(6));
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_ReplacesExistingItem()
+    {
+        var service = CreateService();
+        var updated = new CatalogItem { Id = 1, Name = "Updated Name", Price = 99M };
+
+        service.UpdateCatalogItem(updated);
+
+        var item = service.FindCatalogItem(1);
+        Assert.NotNull(item);
+        Assert.Equal("Updated Name", item!.Name);
+        Assert.Equal(99M, item.Price);
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_ReplacesExistingItem()
+    {
+        var service = CreateService();
+        var updated = new CatalogItem { Id = 2, Name = "Async Updated" };
+
+        await service.UpdateCatalogItemAsync(updated);
+
+        var item = await service.FindCatalogItemAsync(2);
+        Assert.Equal("Async Updated", item!.Name);
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_RemovesById()
+    {
+        var service = CreateService();
+
+        service.RemoveCatalogItem(new CatalogItem { Id = 1 });
+
+        Assert.Null(service.FindCatalogItem(1));
+        Assert.Equal(4, service.GetCatalogItemsPaginated(100, 0).TotalItems);
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_RemovesById()
+    {
+        var service = CreateService();
+
+        await service.RemoveCatalogItemAsync(new CatalogItem { Id = 3 });
+
+        Assert.Null(await service.FindCatalogItemAsync(3));
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var service = CreateService();
+
+        var exception = Record.Exception(() => service.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/ImageMockStorageTests.cs
@@ -1,0 +1,83 @@
+using Xunit;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopCoreModernized.Tests;
+
+public class ImageMockStorageTests
+{
+    private static ImageMockStorage CreateStorage()
+    {
+        var environment = new Mock<IWebHostEnvironment>().Object;
+        return new ImageMockStorage(environment, NullLogger<ImageMockStorage>.Instance);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsPicsRoot()
+    {
+        var storage = CreateStorage();
+
+        Assert.Equal("/pics/", storage.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPng()
+    {
+        var storage = CreateStorage();
+
+        Assert.Equal("/pics/default.png", storage.UrlDefaultImage());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildUrlImage_ReturnsDefault_WhenPictureFileNameMissing(string? pictureFileName)
+    {
+        var storage = CreateStorage();
+        var item = new CatalogItem { Id = 7, PictureFileName = pictureFileName! };
+
+        Assert.Equal("/pics/default.png", storage.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsItemUrl_WhenPictureFileNamePresent()
+    {
+        var storage = CreateStorage();
+        var item = new CatalogItem { Id = 42, PictureFileName = "photo.png" };
+
+        Assert.Equal("/pics/42/photo.png", storage.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CompletesWithoutError()
+    {
+        var storage = CreateStorage();
+
+        var exception = await Record.ExceptionAsync(() => storage.InitializeCatalogImagesAsync());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CompletesWithoutError()
+    {
+        var storage = CreateStorage();
+
+        var exception = await Record.ExceptionAsync(() => storage.UpdateImageAsync(new CatalogItem { Id = 1 }));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var storage = CreateStorage();
+
+        var exception = Record.Exception(() => storage.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/ModelTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/ModelTests.cs
@@ -1,0 +1,88 @@
+using Xunit;
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Tests;
+
+public class ModelTests
+{
+    [Fact]
+    public void CatalogItem_DefaultsPictureFileNameToDummy()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(CatalogItem.DefaultPictureName, item.PictureFileName);
+        Assert.Equal("dummy.png", CatalogItem.DefaultPictureName);
+    }
+
+    [Fact]
+    public void CatalogItem_PropertiesRoundTrip()
+    {
+        var brand = new CatalogBrand { Id = 1, Brand = "Azure" };
+        var type = new CatalogType { Id = 2, Type = "Mug" };
+
+        var item = new CatalogItem
+        {
+            Id = 10,
+            Name = "Test Item",
+            Description = "A description",
+            Price = 12.34M,
+            PictureFileName = "10.png",
+            PictureUri = "/pics/10/10.png",
+            TempImageName = "temp.png",
+            CatalogTypeId = 2,
+            CatalogType = type,
+            CatalogBrandId = 1,
+            CatalogBrand = brand,
+            AvailableStock = 100,
+            RestockThreshold = 5,
+            MaxStockThreshold = 200,
+            OnReorder = true,
+        };
+
+        Assert.Equal(10, item.Id);
+        Assert.Equal("Test Item", item.Name);
+        Assert.Equal("A description", item.Description);
+        Assert.Equal(12.34M, item.Price);
+        Assert.Equal("10.png", item.PictureFileName);
+        Assert.Equal("/pics/10/10.png", item.PictureUri);
+        Assert.Equal("temp.png", item.TempImageName);
+        Assert.Equal(2, item.CatalogTypeId);
+        Assert.Same(type, item.CatalogType);
+        Assert.Equal(1, item.CatalogBrandId);
+        Assert.Same(brand, item.CatalogBrand);
+        Assert.Equal(100, item.AvailableStock);
+        Assert.Equal(5, item.RestockThreshold);
+        Assert.Equal(200, item.MaxStockThreshold);
+        Assert.True(item.OnReorder);
+    }
+
+    [Fact]
+    public void CatalogBrand_PropertiesRoundTrip()
+    {
+        var brand = new CatalogBrand { Id = 3, Brand = "Visual Studio" };
+
+        Assert.Equal(3, brand.Id);
+        Assert.Equal("Visual Studio", brand.Brand);
+    }
+
+    [Fact]
+    public void CatalogBrand_BrandDefaultsToEmptyString()
+    {
+        Assert.Equal(string.Empty, new CatalogBrand().Brand);
+    }
+
+    [Fact]
+    public void CatalogType_PropertiesRoundTrip()
+    {
+        var type = new CatalogType { Id = 4, Type = "USB Memory Stick" };
+
+        Assert.Equal(4, type.Id);
+        Assert.Equal("USB Memory Stick", type.Type);
+    }
+
+    [Fact]
+    public void CatalogType_TypeDefaultsToEmptyString()
+    {
+        Assert.Equal(string.Empty, new CatalogType().Type);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,51 @@
+using Xunit;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.ViewModel;
+
+namespace eShopCoreModernized.Tests;
+
+public class PaginatedItemsViewModelTests
+{
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var data = new List<CatalogItem>
+        {
+            new() { Id = 1, Name = "A" },
+            new() { Id = 2, Name = "B" },
+        };
+
+        var viewModel = new PaginatedItemsViewModel<CatalogItem>(2, 10, 25, data);
+
+        Assert.Equal(2, viewModel.ActualPage);
+        Assert.Equal(10, viewModel.ItemsPerPage);
+        Assert.Equal(25, viewModel.TotalItems);
+        Assert.Equal(data, viewModel.Data);
+    }
+
+    [Theory]
+    [InlineData(0, 10, 0)]
+    [InlineData(10, 10, 1)]
+    [InlineData(11, 10, 2)]
+    [InlineData(25, 10, 3)]
+    [InlineData(5, 5, 1)]
+    [InlineData(1, 10, 1)]
+    [InlineData(100, 7, 15)]
+    public void TotalPages_UsesCeilingCalculation(long count, int pageSize, int expectedPages)
+    {
+        var viewModel = new PaginatedItemsViewModel<CatalogItem>(0, pageSize, count, new List<CatalogItem>());
+
+        Assert.Equal(expectedPages, viewModel.TotalPages);
+    }
+
+    [Fact]
+    public void TotalPages_IsSettable()
+    {
+        var viewModel = new PaginatedItemsViewModel<CatalogItem>(0, 10, 5, new List<CatalogItem>())
+        {
+            TotalPages = 99,
+        };
+
+        Assert.Equal(99, viewModel.TotalPages);
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/eShopCoreModernized/eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Introduces a basic automated testing framework (xUnit) for the .NET 8
`eShopCoreModernized` project. There was previously no test project or solution
file under `eShopModernized/`, so this adds both, plus coverage tooling via
`coverlet.collector`.

**What's added**

- `eShopModernized/tests/eShopCoreModernized.Tests/` — new SDK-style xUnit test
  project (`net8.0`, nullable + implicit usings, `IsPackable=false`). Packages:
  `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`,
  `coverlet.collector`, `Microsoft.EntityFrameworkCore.InMemory` (8.0.x), and
  `Moq`. References `../../src/eShopCoreModernized/eShopModernized.csproj`.
- `eShopModernized/eShopModernized.sln` — new solution including both the source
  project and the test project (for discoverability).
- `eShopModernized/tests/README.md` — how to run tests and collect coverage.

**Tests (43 total, all passing)** target dependency-light classes so they run
without a live database:

- `CatalogServiceMockTests` — `GetCatalogBrands`/`GetCatalogTypes` return seeded
  collections; `GetCatalogItemsPaginated` page size / `ActualPage` / `TotalItems`;
  `FindCatalogItem`(`Async`) hit/miss; `CreateCatalogItem` assigns max+1 Id;
  `UpdateCatalogItem` replaces; `RemoveCatalogItem` removes by id. Both sync and
  async variants covered.
- `ImageMockStorageTests` — `BaseUrl()` → `/pics/`, `UrlDefaultImage()` →
  `/pics/default.png`, `BuildUrlImage` default vs `"/pics/{Id}/{PictureFileName}"`.
  Constructed with `NullLogger<ImageMockStorage>.Instance` and a `Mock<IWebHostEnvironment>`.
- `PaginatedItemsViewModelTests` — property assignment and the `TotalPages`
  ceiling calculation across several count/pageSize combos.
- `ModelTests` — get/set round-trips for `CatalogItem`, `CatalogBrand`, `CatalogType`.

## Coverage

Collected with:

```bash
cd eShopModernized
dotnet test eShopModernized.sln --collect:"XPlat Code Coverage" --results-directory ./TestResults
```

Measured line coverage of the `eShopCoreModernized` assembly (from
`coverage.cobertura.xml`):

| Metric | Value |
| --- | --- |
| Lines covered | 152 / 922 |
| **Line coverage** | **16.48%** (`line-rate=0.1648`) |

This exceeds the 10% threshold.

## Verification

```bash
dotnet build eShopModernized/eShopModernized.sln   # 0 errors
dotnet test  eShopModernized/eShopModernized.sln   # Passed: 43, Failed: 0
```


Link to Devin session: https://app.devin.ai/sessions/5ed7ad8a39574e3ba2b4da52f7b93b49
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/32?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->