### PR TITLE
Add testing framework and initial tests for eShopModernized

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,0 +1,32 @@
+name: eShopModernized .NET Tests
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'eShopModernized/**'
+      - '.github/workflows/dotnet-tests.yml'
+  pull_request:
+    paths:
+      - 'eShopModernized/**'
+      - '.github/workflows/dotnet-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+
+      - name: Build
+        run: dotnet build eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj --configuration Release --no-restore
+
+      - name: Test with coverage
+        run: dotnet test eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj --configuration Release --no-build --collect:"XPlat Code Coverage" --logger "console;verbosity=detailed"

--- a/eShopModernized/tests/README.md
+++ b/eShopModernized/tests/README.md
@@ -1,0 +1,37 @@
+# eShopModernized Tests
+
+Unit tests for the modernized .NET 8 catalog service (`eShopModernized/src/eShopCoreModernized`).
+
+## Stack
+- [xUnit](https://xunit.net/) — test framework
+- [Moq](https://github.com/devlooped/moq) — mocking dependencies
+- [coverlet](https://github.com/coverlet-coverage/coverlet) — code coverage (`XPlat Code Coverage`)
+
+## Layout
+Tests mirror the source folder structure under `eShopModernized.Tests/`:
+
+| Source | Tests |
+| --- | --- |
+| `Services/CatalogServiceMock.cs` | `Services/CatalogServiceMockTests.cs` |
+| `Services/ImageMockStorage.cs` | `Services/ImageMockStorageTests.cs` |
+| `Controllers/BrandsController.cs` | `Controllers/BrandsControllerTests.cs` |
+| `Controllers/CatalogController.cs` | `Controllers/CatalogControllerTests.cs` |
+| `Configuration/CatalogConfiguration.cs` | `Configuration/CatalogConfigurationTests.cs` |
+| `ViewModel/PaginatedItemsViewModel.cs` | `ViewModel/PaginatedItemsViewModelTests.cs` |
+| `Models/*` | `Models/CatalogModelsTests.cs` |
+| `Infrastructure/MigrationTelemetryInitializer.cs` | `Infrastructure/MigrationTelemetryInitializerTests.cs` |
+
+## Running
+
+```bash
+# from repo root
+dotnet test eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+
+# with coverage (produces TestResults/<guid>/coverage.cobertura.xml)
+dotnet test eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj \
+  --collect:"XPlat Code Coverage"
+```
+
+Tests are hermetic — no SQL Server, Azure, or network access is required. External
+boundaries (catalog data, image storage, configuration, telemetry) are mocked or use
+the in-memory mock implementations.

--- a/eShopModernized/tests/eShopModernized.Tests/Configuration/CatalogConfigurationTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Configuration/CatalogConfigurationTests.cs
@@ -1,0 +1,82 @@
+using eShopCoreModernized.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace eShopModernized.Tests.Configuration
+{
+    public class CatalogConfigurationTests
+    {
+        private static CatalogConfiguration Build(Dictionary<string, string?> values)
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+            return new CatalogConfiguration(configuration);
+        }
+
+        [Fact]
+        public void BooleanFlags_ReadFromAppSettings()
+        {
+            var config = Build(new Dictionary<string, string?>
+            {
+                ["AppSettings:UseMockData"] = "true",
+                ["AppSettings:UseAzureStorage"] = "false",
+                ["AppSettings:UseAzureManagedIdentity"] = "true",
+                ["AppSettings:UseCustomizationData"] = "false",
+                ["AppSettings:UseAzureActiveDirectory"] = "true",
+            });
+
+            Assert.True(config.UseMockData);
+            Assert.False(config.UseAzureStorage);
+            Assert.True(config.UseManagedIdentity);
+            Assert.False(config.UseCustomizationData);
+            Assert.True(config.UseAzureActiveDirectory);
+        }
+
+        [Fact]
+        public void BooleanFlags_DefaultToFalseWhenMissing()
+        {
+            var config = Build(new Dictionary<string, string?>());
+
+            Assert.False(config.UseMockData);
+            Assert.False(config.UseAzureStorage);
+            Assert.False(config.UseManagedIdentity);
+            Assert.False(config.UseCustomizationData);
+            Assert.False(config.UseAzureActiveDirectory);
+        }
+
+        [Fact]
+        public void StringValues_ReadFromAzureSection()
+        {
+            var config = Build(new Dictionary<string, string?>
+            {
+                ["Azure:StorageConnectionString"] = "storage-conn",
+                ["Azure:ApplicationInsights:InstrumentationKey"] = "ikey",
+                ["Azure:ApplicationInsights:ConnectionString"] = "ai-conn",
+                ["Azure:ActiveDirectory:ClientId"] = "client-id",
+                ["Azure:ActiveDirectory:TenantId"] = "tenant-id",
+                ["Azure:ActiveDirectory:PostLogoutRedirectUri"] = "https://logout",
+            });
+
+            Assert.Equal("storage-conn", config.StorageConnectionString);
+            Assert.Equal("ikey", config.AppInsightsInstrumentationKey);
+            Assert.Equal("ai-conn", config.AppInsightsConnectionString);
+            Assert.Equal("client-id", config.AzureActiveDirectoryClientId);
+            Assert.Equal("tenant-id", config.AzureActiveDirectoryTenant);
+            Assert.Equal("https://logout", config.PostLogoutRedirectUri);
+        }
+
+        [Fact]
+        public void StringValues_DefaultToEmptyWhenMissing()
+        {
+            var config = Build(new Dictionary<string, string?>());
+
+            Assert.Equal(string.Empty, config.StorageConnectionString);
+            Assert.Equal(string.Empty, config.AppInsightsInstrumentationKey);
+            Assert.Equal(string.Empty, config.AppInsightsConnectionString);
+            Assert.Equal(string.Empty, config.AzureActiveDirectoryClientId);
+            Assert.Equal(string.Empty, config.AzureActiveDirectoryTenant);
+            Assert.Equal(string.Empty, config.PostLogoutRedirectUri);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/BrandsControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/BrandsControllerTests.cs
@@ -1,0 +1,82 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers
+{
+    public class BrandsControllerTests
+    {
+        private static readonly List<CatalogBrand> Brands = new()
+        {
+            new CatalogBrand { Id = 1, Brand = "Azure" },
+            new CatalogBrand { Id = 2, Brand = ".NET" },
+        };
+
+        private static BrandsController CreateController(out Mock<ICatalogService> service)
+        {
+            service = new Mock<ICatalogService>();
+            service.Setup(s => s.GetCatalogBrandsAsync())
+                .ReturnsAsync(Brands);
+            var logger = new Mock<ILogger<BrandsController>>();
+            return new BrandsController(service.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task Get_ReturnsAllBrands()
+        {
+            var controller = CreateController(out _);
+
+            var result = await controller.Get();
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var brands = Assert.IsAssignableFrom<IEnumerable<CatalogBrand>>(ok.Value);
+            Assert.Equal(2, brands.Count());
+        }
+
+        [Fact]
+        public async Task Get_ById_Existing_ReturnsBrand()
+        {
+            var controller = CreateController(out _);
+
+            var result = await controller.Get(1);
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var brand = Assert.IsType<CatalogBrand>(ok.Value);
+            Assert.Equal("Azure", brand.Brand);
+        }
+
+        [Fact]
+        public async Task Get_ById_Unknown_ReturnsNotFound()
+        {
+            var controller = CreateController(out _);
+
+            var result = await controller.Get(999);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task Delete_Existing_ReturnsOk()
+        {
+            var controller = CreateController(out _);
+
+            var result = await controller.Delete(2);
+
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Unknown_ReturnsNotFound()
+        {
+            var controller = CreateController(out _);
+
+            var result = await controller.Delete(999);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
@@ -1,0 +1,114 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.ViewModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers
+{
+    public class CatalogControllerTests
+    {
+        private readonly Mock<ICatalogService> _service = new();
+        private readonly Mock<IImageService> _imageService = new();
+        private readonly Mock<ICatalogConfiguration> _configuration = new();
+
+        private CatalogController CreateController()
+        {
+            _imageService.Setup(s => s.BuildUrlImage(It.IsAny<CatalogItem>())).Returns("/pics/x.png");
+            var logger = new Mock<ILogger<CatalogController>>();
+            return new CatalogController(_service.Object, _imageService.Object, _configuration.Object, logger.Object);
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewWithPaginatedItems()
+        {
+            var items = new List<CatalogItem> { new() { Id = 1, Name = "Item" } };
+            var paginated = new PaginatedItemsViewModel<CatalogItem>(0, 10, 1, items);
+            _service.Setup(s => s.GetCatalogItemsPaginatedAsync(10, 0)).ReturnsAsync(paginated);
+            var controller = CreateController();
+
+            var result = await controller.Index();
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(paginated, view.Model);
+            _imageService.Verify(s => s.BuildUrlImage(It.IsAny<CatalogItem>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Details_NullId_ReturnsBadRequest()
+        {
+            var controller = CreateController();
+
+            var result = await controller.Details(null);
+
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        [Fact]
+        public async Task Details_UnknownId_ReturnsNotFound()
+        {
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync((CatalogItem?)null);
+            var controller = CreateController();
+
+            var result = await controller.Details(5);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Details_ExistingId_ReturnsViewWithItem()
+        {
+            var item = new CatalogItem { Id = 5, Name = "Found" };
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Details(5);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(item, view.Model);
+            Assert.Equal("/pics/x.png", item.PictureUri);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ExistingItem_RemovesAndRedirects()
+        {
+            var item = new CatalogItem { Id = 7 };
+            _service.Setup(s => s.FindCatalogItemAsync(7)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.DeleteConfirmed(7);
+
+            var redirect = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+            _service.Verify(s => s.RemoveCatalogItemAsync(item), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_UnknownItem_RedirectsWithoutRemoving()
+        {
+            _service.Setup(s => s.FindCatalogItemAsync(7)).ReturnsAsync((CatalogItem?)null);
+            var controller = CreateController();
+
+            var result = await controller.DeleteConfirmed(7);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            _service.Verify(s => s.RemoveCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Create_Post_ValidModel_CreatesItemAndRedirects()
+        {
+            var controller = CreateController();
+            var item = new CatalogItem { Name = "New" };
+
+            var result = await controller.Create(item);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Infrastructure/MigrationTelemetryInitializerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Infrastructure/MigrationTelemetryInitializerTests.cs
@@ -1,0 +1,23 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.ApplicationInsights.DataContracts;
+using Xunit;
+
+namespace eShopModernized.Tests.Infrastructure
+{
+    public class MigrationTelemetryInitializerTests
+    {
+        [Fact]
+        public void Initialize_SetsMigrationGlobalProperties()
+        {
+            var initializer = new MigrationTelemetryInitializer();
+            var telemetry = new TraceTelemetry();
+
+            initializer.Initialize(telemetry);
+
+            var properties = telemetry.Context.GlobalProperties;
+            Assert.Equal(".NET Core 6.0", properties["ApplicationVersion"]);
+            Assert.Equal("StranglerFig-Complete", properties["MigrationPhase"]);
+            Assert.Equal("Catalog-Core", properties["ServiceType"]);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Models/CatalogModelsTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Models/CatalogModelsTests.cs
@@ -1,0 +1,70 @@
+using eShopCoreModernized.Models;
+using Xunit;
+
+namespace eShopModernized.Tests.Models
+{
+    public class CatalogModelsTests
+    {
+        [Fact]
+        public void CatalogItem_DefaultConstructor_UsesDefaultPictureName()
+        {
+            var item = new CatalogItem();
+
+            Assert.Equal(CatalogItem.DefaultPictureName, item.PictureFileName);
+            Assert.Equal("dummy.png", item.PictureFileName);
+            Assert.Equal(string.Empty, item.Name);
+        }
+
+        [Fact]
+        public void CatalogItem_Properties_RoundTrip()
+        {
+            var brand = new CatalogBrand { Id = 1, Brand = "Azure" };
+            var type = new CatalogType { Id = 2, Type = "Mug" };
+
+            var item = new CatalogItem
+            {
+                Id = 10,
+                Name = "Mug",
+                Description = "A mug",
+                Price = 9.99M,
+                PictureFileName = "10.png",
+                CatalogBrandId = brand.Id,
+                CatalogBrand = brand,
+                CatalogTypeId = type.Id,
+                CatalogType = type,
+                AvailableStock = 5,
+                RestockThreshold = 1,
+                MaxStockThreshold = 10,
+                OnReorder = true,
+            };
+
+            Assert.Equal(10, item.Id);
+            Assert.Equal("Mug", item.Name);
+            Assert.Equal("A mug", item.Description);
+            Assert.Equal(9.99M, item.Price);
+            Assert.Equal("10.png", item.PictureFileName);
+            Assert.Same(brand, item.CatalogBrand);
+            Assert.Same(type, item.CatalogType);
+            Assert.True(item.OnReorder);
+            Assert.Equal(5, item.AvailableStock);
+        }
+
+        [Fact]
+        public void CatalogBrand_Properties_RoundTrip()
+        {
+            var brand = new CatalogBrand { Id = 3, Brand = "Visual Studio" };
+
+            Assert.Equal(3, brand.Id);
+            Assert.Equal("Visual Studio", brand.Brand);
+        }
+
+        [Fact]
+        public void CatalogType_Properties_RoundTrip()
+        {
+            var type = new CatalogType { Id = 4, Type = "T-Shirt" };
+
+            Assert.Equal(4, type.Id);
+            Assert.Equal("T-Shirt", type.Type);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceMockTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceMockTests.cs
@@ -1,0 +1,208 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Xunit;
+
+namespace eShopModernized.Tests.Services
+{
+    public class CatalogServiceMockTests
+    {
+        private static CatalogServiceMock CreateService() => new CatalogServiceMock();
+
+        [Fact]
+        public void GetCatalogBrands_ReturnsSeededBrands()
+        {
+            var service = CreateService();
+
+            var brands = service.GetCatalogBrands().ToList();
+
+            Assert.Equal(5, brands.Count);
+            Assert.Contains(brands, b => b.Brand == "Azure");
+            Assert.Contains(brands, b => b.Brand == ".NET");
+        }
+
+        [Fact]
+        public void GetCatalogTypes_ReturnsSeededTypes()
+        {
+            var service = CreateService();
+
+            var types = service.GetCatalogTypes().ToList();
+
+            Assert.Equal(4, types.Count);
+            Assert.Contains(types, t => t.Type == "Mug");
+        }
+
+        [Fact]
+        public async Task GetCatalogBrandsAsync_ReturnsSameDataAsSync()
+        {
+            var service = CreateService();
+
+            var brands = await service.GetCatalogBrandsAsync();
+
+            Assert.Equal(5, brands.Count());
+        }
+
+        [Fact]
+        public async Task GetCatalogTypesAsync_ReturnsSameDataAsSync()
+        {
+            var service = CreateService();
+
+            var types = await service.GetCatalogTypesAsync();
+
+            Assert.Equal(4, types.Count());
+        }
+
+        [Fact]
+        public void FindCatalogItem_ExistingId_ReturnsItemWithRelations()
+        {
+            var service = CreateService();
+
+            var item = service.FindCatalogItem(1);
+
+            Assert.NotNull(item);
+            Assert.Equal(".NET Bot Black Hoodie", item!.Name);
+            Assert.NotNull(item.CatalogBrand);
+            Assert.NotNull(item.CatalogType);
+            Assert.Equal(".NET", item.CatalogBrand!.Brand);
+        }
+
+        [Fact]
+        public void FindCatalogItem_UnknownId_ReturnsNull()
+        {
+            var service = CreateService();
+
+            Assert.Null(service.FindCatalogItem(9999));
+        }
+
+        [Fact]
+        public async Task FindCatalogItemAsync_ExistingId_ReturnsItem()
+        {
+            var service = CreateService();
+
+            var item = await service.FindCatalogItemAsync(2);
+
+            Assert.NotNull(item);
+            Assert.Equal(2, item!.Id);
+        }
+
+        [Fact]
+        public void GetCatalogItemsPaginated_FirstPage_RespectsPageSize()
+        {
+            var service = CreateService();
+
+            var page = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+            Assert.Equal(0, page.ActualPage);
+            Assert.Equal(2, page.ItemsPerPage);
+            Assert.Equal(5, page.TotalItems);
+            Assert.Equal(3, page.TotalPages);
+            Assert.Equal(2, page.Data.Count());
+        }
+
+        [Fact]
+        public void GetCatalogItemsPaginated_LastPage_ReturnsRemainingItems()
+        {
+            var service = CreateService();
+
+            var page = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 2);
+
+            Assert.Single(page.Data);
+        }
+
+        [Fact]
+        public async Task GetCatalogItemsPaginatedAsync_ReturnsPagedResult()
+        {
+            var service = CreateService();
+
+            var page = await service.GetCatalogItemsPaginatedAsync(pageSize: 10, pageIndex: 0);
+
+            Assert.Equal(5, page.Data.Count());
+            Assert.Equal(1, page.TotalPages);
+        }
+
+        [Fact]
+        public void CreateCatalogItem_AssignsNextIdAndAddsItem()
+        {
+            var service = CreateService();
+            var newItem = new CatalogItem { Name = "New Item", Price = 1.0M };
+
+            service.CreateCatalogItem(newItem);
+
+            Assert.Equal(6, newItem.Id);
+            Assert.NotNull(service.FindCatalogItem(6));
+        }
+
+        [Fact]
+        public async Task CreateCatalogItemAsync_AddsItem()
+        {
+            var service = CreateService();
+
+            await service.CreateCatalogItemAsync(new CatalogItem { Name = "Async Item" });
+
+            var page = service.GetCatalogItemsPaginated(100, 0);
+            Assert.Equal(6, page.TotalItems);
+        }
+
+        [Fact]
+        public void UpdateCatalogItem_ExistingItem_ReplacesItem()
+        {
+            var service = CreateService();
+            var updated = new CatalogItem { Id = 1, Name = "Updated Name", Price = 99M };
+
+            service.UpdateCatalogItem(updated);
+
+            var item = service.FindCatalogItem(1);
+            Assert.Equal("Updated Name", item!.Name);
+            Assert.Equal(99M, item.Price);
+        }
+
+        [Fact]
+        public void UpdateCatalogItem_UnknownItem_DoesNothing()
+        {
+            var service = CreateService();
+
+            service.UpdateCatalogItem(new CatalogItem { Id = 9999, Name = "ghost" });
+
+            Assert.Null(service.FindCatalogItem(9999));
+        }
+
+        [Fact]
+        public async Task UpdateCatalogItemAsync_ReplacesItem()
+        {
+            var service = CreateService();
+
+            await service.UpdateCatalogItemAsync(new CatalogItem { Id = 2, Name = "Async Updated" });
+
+            Assert.Equal("Async Updated", service.FindCatalogItem(2)!.Name);
+        }
+
+        [Fact]
+        public void RemoveCatalogItem_ExistingItem_RemovesIt()
+        {
+            var service = CreateService();
+
+            service.RemoveCatalogItem(new CatalogItem { Id = 1 });
+
+            Assert.Null(service.FindCatalogItem(1));
+        }
+
+        [Fact]
+        public async Task RemoveCatalogItemAsync_RemovesIt()
+        {
+            var service = CreateService();
+
+            await service.RemoveCatalogItemAsync(new CatalogItem { Id = 3 });
+
+            Assert.Null(service.FindCatalogItem(3));
+        }
+
+        [Fact]
+        public void Dispose_DoesNotThrow()
+        {
+            var service = CreateService();
+
+            var exception = Record.Exception(() => service.Dispose());
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/ImageMockStorageTests.cs
@@ -1,0 +1,83 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Services
+{
+    public class ImageMockStorageTests
+    {
+        private static ImageMockStorage CreateStorage()
+        {
+            var environment = new Mock<IWebHostEnvironment>();
+            var logger = new Mock<ILogger<ImageMockStorage>>();
+            return new ImageMockStorage(environment.Object, logger.Object);
+        }
+
+        [Fact]
+        public void BaseUrl_ReturnsPicsRoot()
+        {
+            Assert.Equal("/pics/", CreateStorage().BaseUrl());
+        }
+
+        [Fact]
+        public void UrlDefaultImage_ReturnsDefaultPng()
+        {
+            Assert.Equal("/pics/default.png", CreateStorage().UrlDefaultImage());
+        }
+
+        [Fact]
+        public void BuildUrlImage_WithPictureFileName_ReturnsItemScopedUrl()
+        {
+            var item = new CatalogItem { Id = 42, PictureFileName = "42.png" };
+
+            Assert.Equal("/pics/42/42.png", CreateStorage().BuildUrlImage(item));
+        }
+
+        [Fact]
+        public void BuildUrlImage_WithoutPictureFileName_ReturnsDefaultImage()
+        {
+            var item = new CatalogItem { Id = 42, PictureFileName = string.Empty };
+
+            Assert.Equal("/pics/default.png", CreateStorage().BuildUrlImage(item));
+        }
+
+        [Fact]
+        public async Task InitializeCatalogImagesAsync_CompletesWithoutError()
+        {
+            var exception = await Record.ExceptionAsync(() => CreateStorage().InitializeCatalogImagesAsync());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public async Task UpdateImageAsync_CompletesWithoutError()
+        {
+            var exception = await Record.ExceptionAsync(() => CreateStorage().UpdateImageAsync(new CatalogItem { Id = 1 }));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public async Task UploadTempImageAsync_ReturnsTempUrlWithFileName()
+        {
+            var file = new Mock<IFormFile>();
+            file.SetupGet(f => f.FileName).Returns("photo.png");
+
+            var url = await CreateStorage().UploadTempImageAsync(file.Object, 7);
+
+            Assert.Equal("/pics/temp/photo.png", url);
+        }
+
+        [Fact]
+        public void Dispose_DoesNotThrow()
+        {
+            var exception = Record.Exception(() => CreateStorage().Dispose());
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ViewModel/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ViewModel/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,33 @@
+using eShopCoreModernized.ViewModel;
+using Xunit;
+
+namespace eShopModernized.Tests.ViewModel
+{
+    public class PaginatedItemsViewModelTests
+    {
+        [Theory]
+        [InlineData(0, 10, 0, 0)]
+        [InlineData(0, 10, 10, 1)]
+        [InlineData(0, 10, 11, 2)]
+        [InlineData(0, 3, 10, 4)]
+        public void Constructor_ComputesTotalPages(int pageIndex, int pageSize, long count, int expectedPages)
+        {
+            var model = new PaginatedItemsViewModel<string>(pageIndex, pageSize, count, new List<string>());
+
+            Assert.Equal(expectedPages, model.TotalPages);
+        }
+
+        [Fact]
+        public void Constructor_AssignsProvidedValues()
+        {
+            var data = new List<string> { "a", "b" };
+
+            var model = new PaginatedItemsViewModel<string>(pageIndex: 2, pageSize: 5, count: 12, data: data);
+
+            Assert.Equal(2, model.ActualPage);
+            Assert.Equal(5, model.ItemsPerPage);
+            Assert.Equal(12, model.TotalItems);
+            Assert.Same(data, model.Data);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\eShopCoreModernized\eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
@@ -16,6 +16,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
The repo had no test project or CI. This adds a basic xUnit testing framework for the modernized .NET 8 catalog service (`eShopModernized/src/eShopCoreModernized`) plus an initial suite that brings line coverage of that assembly to **28.3%** (target was 10% to start).

New test project `eShopModernized/tests/eShopModernized.Tests` (xUnit + Moq + coverlet), with tests mirroring the source layout:

- `CatalogServiceMock` — CRUD, pagination, find, brands/types (sync + async)
- `ImageMockStorage` — URL building, default image fallback, upload/init no-ops
- `BrandsController` / `CatalogController` — happy paths + `NotFound`/`BadRequest`/redirect branches (services mocked)
- `CatalogConfiguration` — bool/string config reads with in-memory `IConfiguration`, including missing-key defaults
- `PaginatedItemsViewModel` — `TotalPages` ceiling math
- Models (`CatalogItem` default picture name, property round-trips)
- `MigrationTelemetryInitializer` — global telemetry properties

All 52 tests pass. Tests are hermetic — no SQL Server / Azure / network; external boundaries are mocked or use the in-memory mock implementations.

### Running
```bash
dotnet test eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj \
  --collect:"XPlat Code Coverage"
# => Passed! Failed: 0, Passed: 52 ; package line-rate ~0.283
```

### CI
Adds `.github/workflows/dotnet-tests.yml` (the repo had no workflows): sets up .NET 8, restores/builds/tests with coverage on pushes and PRs touching `eShopModernized/**`.


Link to Devin session: https://app.devin.ai/sessions/80870e9805bd441f80a2d1379d7184ea
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/34?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->