### PR TITLE
Add brand & type filtering to catalog table

### DIFF
--- a/eShopModernized/src/eShopCoreModernized/Controllers/CatalogController.cs
+++ b/eShopModernized/src/eShopCoreModernized/Controllers/CatalogController.cs
@@ -26,10 +26,19 @@ namespace eShopCoreModernized.Controllers
             _logger = logger;
         }
 
-        public async Task<IActionResult> Index(int pageSize = 10, int pageIndex = 0)
+        public async Task<IActionResult> Index(int pageSize = 10, int pageIndex = 0, int? brandId = null, int? typeId = null)
         {
-            _logger.LogInformation("Now loading... /Catalog/Index?pageSize={PageSize}&pageIndex={PageIndex}", pageSize, pageIndex);
-            var paginatedItems = await _service.GetCatalogItemsPaginatedAsync(pageSize, pageIndex);
+            _logger.LogInformation("Now loading... /Catalog/Index?pageSize={PageSize}&pageIndex={PageIndex}&brandId={BrandId}&typeId={TypeId}", pageSize, pageIndex, brandId, typeId);
+
+            var brands = await _service.GetCatalogBrandsAsync();
+            var types = await _service.GetCatalogTypesAsync();
+
+            ViewBag.Brands = brands;
+            ViewBag.Types = types;
+            ViewBag.BrandFilterApplied = brandId;
+            ViewBag.TypeFilterApplied = typeId;
+
+            var paginatedItems = await _service.GetCatalogItemsPaginatedAsync(pageSize, pageIndex, brandId, typeId);
             ChangeUriPlaceholder(paginatedItems.Data);
             return View(paginatedItems);
         }

--- a/eShopModernized/src/eShopCoreModernized/Services/CatalogService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/CatalogService.cs
@@ -15,13 +15,21 @@ namespace eShopCoreModernized.Services
             this.indexGenerator = indexGenerator;
         }
 
-        public async Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex)
+        public async Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandId = null, int? typeId = null)
         {
-            var totalItems = await db.CatalogItems.LongCountAsync();
-
-            var itemsOnPage = await db.CatalogItems
+            var query = db.CatalogItems
                 .Include(c => c.CatalogBrand)
                 .Include(c => c.CatalogType)
+                .AsQueryable();
+
+            if (brandId.HasValue)
+                query = query.Where(c => c.CatalogBrandId == brandId.Value);
+            if (typeId.HasValue)
+                query = query.Where(c => c.CatalogTypeId == typeId.Value);
+
+            var totalItems = await query.LongCountAsync();
+
+            var itemsOnPage = await query
                 .OrderBy(c => c.Id)
                 .Skip(pageSize * pageIndex)
                 .Take(pageSize)
@@ -31,13 +39,21 @@ namespace eShopCoreModernized.Services
                 pageIndex, pageSize, totalItems, itemsOnPage);
         }
 
-        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex)
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandId = null, int? typeId = null)
         {
-            var totalItems = db.CatalogItems.LongCount();
-
-            var itemsOnPage = db.CatalogItems
+            var query = db.CatalogItems
                 .Include(c => c.CatalogBrand)
                 .Include(c => c.CatalogType)
+                .AsQueryable();
+
+            if (brandId.HasValue)
+                query = query.Where(c => c.CatalogBrandId == brandId.Value);
+            if (typeId.HasValue)
+                query = query.Where(c => c.CatalogTypeId == typeId.Value);
+
+            var totalItems = query.LongCount();
+
+            var itemsOnPage = query
                 .OrderBy(c => c.Id)
                 .Skip(pageSize * pageIndex)
                 .Take(pageSize)

--- a/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
@@ -44,15 +44,23 @@ namespace eShopCoreModernized.Services
             }
         }
 
-        public Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex)
+        public Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandId = null, int? typeId = null)
         {
-            return Task.FromResult(GetCatalogItemsPaginated(pageSize, pageIndex));
+            return Task.FromResult(GetCatalogItemsPaginated(pageSize, pageIndex, brandId, typeId));
         }
 
-        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex)
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandId = null, int? typeId = null)
         {
-            var totalItems = catalogItems.Count;
-            var itemsOnPage = catalogItems
+            var filtered = catalogItems.AsEnumerable();
+
+            if (brandId.HasValue)
+                filtered = filtered.Where(c => c.CatalogBrandId == brandId.Value);
+            if (typeId.HasValue)
+                filtered = filtered.Where(c => c.CatalogTypeId == typeId.Value);
+
+            var filteredList = filtered.ToList();
+            var totalItems = filteredList.Count;
+            var itemsOnPage = filteredList
                 .Skip(pageSize * pageIndex)
                 .Take(pageSize)
                 .ToList();

--- a/eShopModernized/src/eShopCoreModernized/Services/ICatalogService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/ICatalogService.cs
@@ -9,8 +9,8 @@ namespace eShopCoreModernized.Services
         CatalogItem? FindCatalogItem(int id);
         Task<IEnumerable<CatalogBrand>> GetCatalogBrandsAsync();
         IEnumerable<CatalogBrand> GetCatalogBrands();
-        Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex);
-        PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex);
+        Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandId = null, int? typeId = null);
+        PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandId = null, int? typeId = null);
         Task<IEnumerable<CatalogType>> GetCatalogTypesAsync();
         IEnumerable<CatalogType> GetCatalogTypes();
         Task CreateCatalogItemAsync(CatalogItem catalogItem);

--- a/eShopModernized/src/eShopCoreModernized/Views/Catalog/Index.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Catalog/Index.cshtml
@@ -2,12 +2,51 @@
 
 @{
     ViewBag.Title = "Index";
+    var brands = ViewBag.Brands as IEnumerable<eShopCoreModernized.Models.CatalogBrand>;
+    var types = ViewBag.Types as IEnumerable<eShopCoreModernized.Models.CatalogType>;
+    int? brandFilter = ViewBag.BrandFilterApplied as int?;
+    int? typeFilter = ViewBag.TypeFilterApplied as int?;
 }
 
 <div class="esh-table">
     <p class="esh-link-wrapper">
         @Html.ActionLink("Create New", "Create", null, new { @class = "btn esh-button esh-button-primary" })
     </p>
+
+    <form method="get" asp-action="Index" class="esh-catalog-filters">
+        <div class="row mb-3 align-items-end">
+            <div class="col-auto">
+                <label class="form-label fw-bold">Brand</label>
+                <select name="brandId" class="form-select" onchange="this.form.submit()">
+                    <option value="">All Brands</option>
+                    @if (brands != null)
+                    {
+                        @foreach (var brand in brands)
+                        {
+                            <option value="@brand.Id" selected="@(brandFilter == brand.Id)">@brand.Brand</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-auto">
+                <label class="form-label fw-bold">Type</label>
+                <select name="typeId" class="form-select" onchange="this.form.submit()">
+                    <option value="">All Types</option>
+                    @if (types != null)
+                    {
+                        @foreach (var type in types)
+                        {
+                            <option value="@type.Id" selected="@(typeFilter == type.Id)">@type.Type</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="col-auto">
+                <a href="@Url.Action("Index")" class="btn btn-outline-secondary">Reset Filters</a>
+            </div>
+        </div>
+        <input type="hidden" name="pageSize" value="@Model.ItemsPerPage" />
+    </form>
 
     <partial name="CatalogTable" model="Model.Data" />
 
@@ -18,11 +57,11 @@
 
                     @if (Model.ActualPage > 0)
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, brandId = brandFilter, typeId = typeFilter }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, brandId = brandFilter, typeId = typeFilter }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
                     <span class="esh-pager-item">
@@ -31,11 +70,11 @@
 
                     @if (Model.ActualPage < Model.TotalPages - 1)
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, brandId = brandFilter, typeId = typeFilter }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, brandId = brandFilter, typeId = typeFilter }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
             </nav>


### PR DESCRIPTION
## Summary

Adds brand and type dropdown filters to the catalog index page so users can narrow the product table by `CatalogBrand` and `CatalogType`.

**Service layer** — `ICatalogService.GetCatalogItemsPaginated[Async]` gains optional `int? brandId` and `int? typeId` parameters (default `null` = no filter):

```csharp
// ICatalogService
Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(
    int pageSize, int pageIndex, int? brandId = null, int? typeId = null);
```

`CatalogService` applies EF Core `.Where()` clauses before counting and paging; `CatalogServiceMock` filters the in-memory list equivalently.

**Controller** — `CatalogController.Index` now accepts `brandId` / `typeId` query params, fetches brands and types for the dropdowns, and passes the active filter values via `ViewBag`.

**View** — `Index.cshtml` renders two `<select>` dropdowns (Brand / Type) inside a `<form>` that auto-submits on change. Pagination links (`Previous` / `Next`) preserve the active `brandId` and `typeId` across pages. A "Reset Filters" link clears all filters.

Link to Devin session: https://app.devin.ai/sessions/f41838889ce94099b38846903e457ba7
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/35?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->