### PR TITLE
Test PicController to 80%+ (image serving branches)

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/PicControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/PicControllerTests.cs
@@ -1,0 +1,121 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers
+{
+    public class PicControllerTests : IDisposable
+    {
+        private readonly Mock<ICatalogService> _service = new();
+        private readonly Mock<IWebHostEnvironment> _environment = new();
+        private readonly string _webRoot;
+
+        public PicControllerTests()
+        {
+            _webRoot = Path.Combine(Path.GetTempPath(), "pic-controller-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(_webRoot, "Pics"));
+            _environment.SetupGet(e => e.WebRootPath).Returns(_webRoot);
+            _environment.SetupGet(e => e.ContentRootPath).Returns(_webRoot);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_webRoot))
+            {
+                Directory.Delete(_webRoot, recursive: true);
+            }
+        }
+
+        private PicController CreateController()
+        {
+            var logger = new Mock<ILogger<PicController>>();
+            return new PicController(_service.Object, logger.Object, _environment.Object);
+        }
+
+        private string WritePicture(string fileName)
+        {
+            var path = Path.Combine(_webRoot, "Pics", fileName);
+            File.WriteAllBytes(path, new byte[] { 1, 2, 3, 4 });
+            return path;
+        }
+
+        [Fact]
+        public async Task Index_NonPositiveId_ReturnsBadRequest()
+        {
+            var controller = CreateController();
+
+            var result = await controller.Index(0);
+
+            Assert.IsType<BadRequestResult>(result);
+            _service.Verify(s => s.FindCatalogItemAsync(It.IsAny<int>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Index_UnknownItem_ReturnsNotFound()
+        {
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync((CatalogItem?)null);
+            var controller = CreateController();
+
+            var result = await controller.Index(5);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Index_ItemFoundButFileMissing_ReturnsNotFound()
+        {
+            var item = new CatalogItem { Id = 5, PictureFileName = "missing.png" };
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Index(5);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Theory]
+        [InlineData("1.png", "image/png")]
+        [InlineData("2.jpg", "image/jpeg")]
+        [InlineData("3.jpeg", "image/jpeg")]
+        [InlineData("4.gif", "image/gif")]
+        [InlineData("5.bmp", "image/bmp")]
+        [InlineData("6.tiff", "image/tiff")]
+        [InlineData("7.wmf", "image/wmf")]
+        [InlineData("8.jp2", "image/jp2")]
+        [InlineData("9.svg", "image/svg+xml")]
+        [InlineData("10.unknown", "application/octet-stream")]
+        public async Task Index_ItemFoundAndFileExists_ReturnsFileWithExpectedMimeType(string fileName, string expectedMime)
+        {
+            WritePicture(fileName);
+            var item = new CatalogItem { Id = 5, PictureFileName = fileName };
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Index(5);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal(expectedMime, fileResult.ContentType);
+            Assert.Equal(new byte[] { 1, 2, 3, 4 }, fileResult.FileContents);
+        }
+
+        [Fact]
+        public async Task Index_WebRootPathNull_FallsBackToContentRootPath()
+        {
+            _environment.SetupGet(e => e.WebRootPath).Returns((string?)null!);
+            WritePicture("fallback.png");
+            var item = new CatalogItem { Id = 5, PictureFileName = "fallback.png" };
+            _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Index(5);
+
+            var fileResult = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("image/png", fileResult.ContentType);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds focused unit tests for `PicController.Index(catalogItemId)` covering every branch, bringing `Controllers/PicController.cs` to **100% line coverage (78/78)**.

New file: `tests/eShopModernized.Tests/Controllers/PicControllerTests.cs` (follows the existing xUnit + Moq style; mocks `ICatalogService`, `ILogger<PicController>`, `IWebHostEnvironment`). Tests are hermetic — a unique temp dir is created per test class and a `Pics` folder + small files are written to disk, with `WebRootPath`/`ContentRootPath` pointed at it; everything is cleaned up via `IDisposable`.

Branches covered:
- `catalogItemId <= 0` → `BadRequestResult` (and verifies the service is never queried).
- item not found (`FindCatalogItemAsync` → null) → `NotFoundResult`.
- item found but picture file missing on disk → `NotFoundResult`.
- item found + file exists → `FileContentResult` with correct content + MIME type. A `[Theory]` exercises every arm of the private `GetImageMimeTypeFromImageFileExtension` switch (`.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`, `.tiff`, `.wmf`, `.jp2`, `.svg`, and an unknown extension → `application/octet-stream`).
- `WebRootPath == null` fallback to `ContentRootPath`.

## Verification
- `dotnet test` → all **66** tests pass (10 new test cases here).
- Coverage (cobertura): `Controllers/PicController.cs` = 100.0% (78/78).

No production code under `src/` was modified.

Link to Devin session: https://app.devin.ai/sessions/e2e0b40175b14dd4bc8778e890bbdce0
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/36?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->