### PR TITLE
Test ImageUploadController to 80%+ (upload validation + default image)

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/ImageUploadControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/ImageUploadControllerTests.cs
@@ -1,0 +1,138 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers
+{
+    public class ImageUploadControllerTests
+    {
+        private readonly Mock<IImageService> _imageService = new();
+        private readonly Mock<ILogger<ImageUploadController>> _logger = new();
+
+        private ImageUploadController CreateController() =>
+            new(_imageService.Object, _logger.Object);
+
+        private static Mock<IFormFile> CreateFile(string fileName, long length)
+        {
+            var file = new Mock<IFormFile>();
+            file.SetupGet(f => f.FileName).Returns(fileName);
+            file.SetupGet(f => f.Length).Returns(length);
+            return file;
+        }
+
+        [Fact]
+        public async Task UploadImage_NullFile_ReturnsBadRequest()
+        {
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(null!, 1);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("No file uploaded", badRequest.Value);
+        }
+
+        [Fact]
+        public async Task UploadImage_EmptyFile_ReturnsBadRequest()
+        {
+            var file = CreateFile("image.png", 0);
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(file.Object, 1);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("No file uploaded", badRequest.Value);
+        }
+
+        [Fact]
+        public async Task UploadImage_DisallowedExtension_ReturnsBadRequest()
+        {
+            var file = CreateFile("document.txt", 10);
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(file.Object, 1);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("Invalid file type", badRequest.Value!.ToString());
+            _imageService.Verify(
+                s => s.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()),
+                Times.Never);
+        }
+
+        [Theory]
+        [InlineData("image.png")]
+        [InlineData("image.jpg")]
+        [InlineData("image.jpeg")]
+        [InlineData("image.gif")]
+        public async Task UploadImage_AllowedExtension_ReturnsOkWithImageUrl(string fileName)
+        {
+            const string expectedUrl = "/pics/temp/uploaded.png";
+            var file = CreateFile(fileName, 123);
+            _imageService
+                .Setup(s => s.UploadTempImageAsync(file.Object, 42))
+                .ReturnsAsync(expectedUrl);
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(file.Object, 42);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(expectedUrl, GetImageUrl(ok.Value));
+            _imageService.Verify(s => s.UploadTempImageAsync(file.Object, 42), Times.Once);
+        }
+
+        [Fact]
+        public async Task UploadImage_NullCatalogItemId_ReturnsOk()
+        {
+            const string expectedUrl = "/pics/temp/uploaded.png";
+            var file = CreateFile("image.png", 50);
+            _imageService
+                .Setup(s => s.UploadTempImageAsync(file.Object, null))
+                .ReturnsAsync(expectedUrl);
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(file.Object);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(expectedUrl, GetImageUrl(ok.Value));
+        }
+
+        [Fact]
+        public async Task UploadImage_ServiceThrows_Returns500()
+        {
+            var file = CreateFile("image.png", 50);
+            _imageService
+                .Setup(s => s.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()))
+                .ThrowsAsync(new Exception("boom"));
+            var controller = CreateController();
+
+            var result = await controller.UploadImage(file.Object, 1);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(500, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public void GetDefaultImage_ReturnsOkWithDefaultUrl()
+        {
+            const string defaultUrl = "/pics/default.png";
+            _imageService.Setup(s => s.UrlDefaultImage()).Returns(defaultUrl);
+            var controller = CreateController();
+
+            var result = controller.GetDefaultImage();
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(defaultUrl, GetImageUrl(ok.Value));
+        }
+
+        private static string? GetImageUrl(object? value)
+        {
+            Assert.NotNull(value);
+            var property = value!.GetType().GetProperty("imageUrl");
+            Assert.NotNull(property);
+            return property!.GetValue(value) as string;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds focused unit tests for `ImageUploadController`, driving it from 0% to **100% line coverage (54/54)**. No production code changed.

New file: `tests/eShopModernized.Tests/Controllers/ImageUploadControllerTests.cs`. `IImageService` and `ILogger<ImageUploadController>` are mocked with Moq; `IFormFile` is mocked for `FileName`/`Length`. Follows the existing `CatalogControllerTests` style.

Cases covered:
- `UploadImage`:
  - `file == null` → `BadRequestObjectResult("No file uploaded")`
  - `file.Length == 0` → `BadRequestObjectResult("No file uploaded")`
  - disallowed extension (`.txt`) → `BadRequestObjectResult` ("Invalid file type"), service never called
  - allowed extensions (`.png`/`.jpg`/`.jpeg`/`.gif`, theory) happy path → calls `UploadTempImageAsync(file, id)`, returns `OkObjectResult` with `{ imageUrl }`
  - null `catalogItemId` happy path → `OkObjectResult`
  - service throws → `ObjectResult` with `StatusCode == 500`
- `GetDefaultImage` → `OkObjectResult` with `{ imageUrl }` from `UrlDefaultImage()`

The anonymous `{ imageUrl }` response is asserted via a small reflection helper (`GetImageUrl`).

## Verification
- `dotnet test` green: **62 passed, 0 failed** (all pre-existing tests still pass).
- Coverage for `Controllers/ImageUploadController.cs`: **100.0% (54/54)**.


Link to Devin session: https://app.devin.ai/sessions/1e83f0f743424dfb85bdc160dd7fdfcc
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/37?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->