### PR TITLE
Test FilesController to 80%+

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/FilesControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/FilesControllerTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers
+{
+    public class FilesControllerTests
+    {
+        private readonly Mock<ICatalogService> _service = new();
+        private readonly Mock<ILogger<FilesController>> _logger = new();
+
+        private FilesController CreateController() => new(_service.Object, _logger.Object);
+
+        [Fact]
+        public async Task Get_ReturnsJsonFileResultWithBrands()
+        {
+            var brands = new List<CatalogBrand>
+            {
+                new() { Id = 1, Brand = "Azure" },
+                new() { Id = 2, Brand = "Visual Studio" }
+            };
+            _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(brands);
+            var controller = CreateController();
+
+            var result = await controller.Get();
+
+            var file = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("application/json", file.ContentType);
+
+            var dtos = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(file.FileContents);
+            Assert.NotNull(dtos);
+            Assert.Equal(2, dtos!.Count);
+            Assert.Equal(1, dtos[0].Id);
+            Assert.Equal("Azure", dtos[0].Brand);
+            Assert.Equal(2, dtos[1].Id);
+            Assert.Equal("Visual Studio", dtos[1].Brand);
+            _service.Verify(s => s.GetCatalogBrandsAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task Get_NoBrands_ReturnsEmptyJsonArray()
+        {
+            _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+            var controller = CreateController();
+
+            var result = await controller.Get();
+
+            var file = Assert.IsType<FileContentResult>(result);
+            Assert.Equal("application/json", file.ContentType);
+
+            var dtos = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(file.FileContents);
+            Assert.NotNull(dtos);
+            Assert.Empty(dtos!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds hermetic unit tests for `FilesController` (and its nested `BrandDTO`), bringing it to **100% line coverage** (34/34).

`FilesController.Get()` calls `ICatalogService.GetCatalogBrandsAsync()`, projects each `CatalogBrand` into a `BrandDTO { Id, Brand }`, serializes to UTF-8 JSON, and returns a `FileContentResult` (`application/json`).

New file: `tests/eShopModernized.Tests/Controllers/FilesControllerTests.cs`
- Mocks `ICatalogService` and `ILogger<FilesController>`.
- `Get_ReturnsJsonFileResultWithBrands`: asserts `FileContentResult`, `ContentType == "application/json"`, and that deserializing `FileContents` round-trips the brand `Id`/`Brand` values (also exercises `BrandDTO` properties).
- `Get_NoBrands_ReturnsEmptyJsonArray`: empty-list edge case yields an empty JSON array.

No production code changed. Full suite green (54 tests pass).

Coverage:
```
100.0%  34/34  Controllers/FilesController.cs
```

Link to Devin session: https://app.devin.ai/sessions/67b14d4f865c4e589a1abb4e21314672
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/38?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->