### PR TITLE
Test SqlConnectionFactory to 80%+ (AppSettings + ManagedIdentity)

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Infrastructure/SqlConnectionFactoryTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Infrastructure/SqlConnectionFactoryTests.cs
@@ -1,0 +1,73 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace eShopModernized.Tests.Infrastructure
+{
+    public class SqlConnectionFactoryTests
+    {
+        private static IConfiguration BuildConfiguration(string? connectionString)
+        {
+            var values = new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:CatalogDBContext"] = connectionString,
+            };
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+        }
+
+        [Fact]
+        public void AppSettings_CreateConnection_ReturnsSqlConnectionWithConfiguredConnectionString()
+        {
+            const string connectionString = "Server=tcp:test.database.windows.net;Database=Catalog;User Id=sa;Password=Pass@word1;";
+            var factory = new AppSettingsSqlConnectionFactory(BuildConfiguration(connectionString));
+
+            using var connection = factory.CreateConnection();
+
+            Assert.IsType<SqlConnection>(connection);
+            Assert.Equal(connectionString, connection.ConnectionString);
+        }
+
+        [Fact]
+        public void AppSettings_CreateConnection_DoesNotOpenConnection()
+        {
+            var factory = new AppSettingsSqlConnectionFactory(
+                BuildConfiguration("Server=tcp:test.database.windows.net;Database=Catalog;User Id=sa;Password=Pass@word1;"));
+
+            using var connection = factory.CreateConnection();
+
+            Assert.Equal(System.Data.ConnectionState.Closed, connection.State);
+        }
+
+        [Fact]
+        public void AppSettings_CreateConnection_WithMissingConnectionString_ReturnsEmptyConnectionString()
+        {
+            var factory = new AppSettingsSqlConnectionFactory(BuildConfiguration(null));
+
+            using var connection = factory.CreateConnection();
+
+            Assert.IsType<SqlConnection>(connection);
+            Assert.Equal(string.Empty, connection.ConnectionString);
+        }
+
+        [Fact]
+        public void ManagedIdentity_Constructor_DoesNotThrow()
+        {
+            var factory = new ManagedIdentitySqlConnectionFactory(
+                BuildConfiguration("Server=tcp:test.database.windows.net;Database=Catalog;"));
+
+            Assert.NotNull(factory);
+        }
+
+        [Fact]
+        public void ManagedIdentity_CreateConnection_ThrowsWithoutAzureCredentials()
+        {
+            var factory = new ManagedIdentitySqlConnectionFactory(
+                BuildConfiguration("Server=tcp:test.database.windows.net;Database=Catalog;"));
+
+            Assert.ThrowsAny<Exception>(() => factory.CreateConnection());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds hermetic unit tests for `Infrastructure/SqlConnectionFactory.cs`, covering both `AppSettingsSqlConnectionFactory` and `ManagedIdentitySqlConnectionFactory`. No production code changed.

New file: `tests/eShopModernized.Tests/Infrastructure/SqlConnectionFactoryTests.cs`, following the existing in-memory `IConfiguration` style (`ConfigurationBuilder().AddInMemoryCollection(...)` with `ConnectionStrings:CatalogDBContext`).

Tests:
- `AppSettings` → `CreateConnection()` returns a `SqlConnection` whose `ConnectionString` equals the configured value; missing connection string yields empty; connection stays `Closed` (no real DB opened — hermetic).
- `ManagedIdentity` → constructor instantiates (creates `DefaultAzureCredential`), and `CreateConnection()` is asserted to throw (`Assert.ThrowsAny<Exception>`), which still executes the connection-string read, `SqlConnection` creation, and the `_credential.GetToken(...)` call.

## Coverage achieved (cobertura)
- File `Infrastructure/SqlConnectionFactory.cs`: **85.7%** (36/42) — meets ≥80%.
- `AppSettingsSqlConnectionFactory`: **100%** (16/16).
- `ManagedIdentitySqlConnectionFactory`: **76.9%** (20/26).

Uncovered lines in `ManagedIdentitySqlConnectionFactory` are 30, 32, 33 — i.e. `connection.AccessToken = token.Token;`, `return connection;` and the closing brace. These run only *after* `_credential.GetToken(...)` succeeds, which requires a real Azure managed-identity/credential environment and throws in CI. They cannot be reached without real cloud credentials, and no production code was modified to work around this. The overall file still exceeds the 80% target.

All tests pass: `dotnet test` → 57 passed, 0 failed.

Link to Devin session: https://app.devin.ai/sessions/6d223a6f252a47aab5bbc698c5585db6
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/39?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->