### PR TITLE
Extend CatalogController tests to 80%+ (Create/Edit/Delete branches)

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
@@ -110,5 +110,178 @@ namespace eShopModernized.Tests.Controllers
             Assert.IsType<RedirectToActionResult>(result);
             _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
         }
+
+        private void SetupBrandsAndTypes()
+        {
+            _service.Setup(s => s.GetCatalogBrandsAsync())
+                .ReturnsAsync(new List<CatalogBrand> { new() { Id = 1, Brand = "Brand1" } });
+            _service.Setup(s => s.GetCatalogTypesAsync())
+                .ReturnsAsync(new List<CatalogType> { new() { Id = 2, Type = "Type1" } });
+        }
+
+        [Fact]
+        public async Task Create_Get_ReturnsViewWithDefaultsAndViewBag()
+        {
+            SetupBrandsAndTypes();
+            _configuration.Setup(c => c.UseAzureStorage).Returns(true);
+            _imageService.Setup(s => s.UrlDefaultImage()).Returns("/pics/default.png");
+            var controller = CreateController();
+
+            var result = await controller.Create();
+
+            var view = Assert.IsType<ViewResult>(result);
+            var item = Assert.IsType<CatalogItem>(view.Model);
+            Assert.Equal("/pics/default.png", item.PictureUri);
+            Assert.NotNull(controller.ViewBag.CatalogBrandId);
+            Assert.NotNull(controller.ViewBag.CatalogTypeId);
+            Assert.True((bool)controller.ViewBag.UseAzureStorage);
+        }
+
+        [Fact]
+        public async Task Create_Post_InvalidModel_ReturnsViewWithoutCreating()
+        {
+            SetupBrandsAndTypes();
+            var controller = CreateController();
+            controller.ModelState.AddModelError("Name", "required");
+            var item = new CatalogItem { CatalogBrandId = 1, CatalogTypeId = 2 };
+
+            var result = await controller.Create(item);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(item, view.Model);
+            _service.Verify(s => s.CreateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Create_Post_ValidModelWithTempImage_SetsFileNameAndUpdatesImage()
+        {
+            var controller = CreateController();
+            var item = new CatalogItem { Name = "New", TempImageName = "/tmp/uploads/photo.png" };
+
+            var result = await controller.Create(item);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("photo.png", item.PictureFileName);
+            _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+            _imageService.Verify(s => s.UpdateImageAsync(item), Times.Once);
+        }
+
+        [Fact]
+        public async Task Edit_Get_NullId_ReturnsBadRequest()
+        {
+            var controller = CreateController();
+
+            var result = await controller.Edit((int?)null);
+
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        [Fact]
+        public async Task Edit_Get_UnknownId_ReturnsNotFound()
+        {
+            _service.Setup(s => s.FindCatalogItemAsync(9)).ReturnsAsync((CatalogItem?)null);
+            var controller = CreateController();
+
+            var result = await controller.Edit(9);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Edit_Get_ExistingId_ReturnsViewWithViewBag()
+        {
+            SetupBrandsAndTypes();
+            _configuration.Setup(c => c.UseAzureStorage).Returns(false);
+            var item = new CatalogItem { Id = 3, Name = "Existing", CatalogBrandId = 1, CatalogTypeId = 2 };
+            _service.Setup(s => s.FindCatalogItemAsync(3)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Edit(3);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(item, view.Model);
+            Assert.Equal("/pics/x.png", item.PictureUri);
+            Assert.NotNull(controller.ViewBag.CatalogBrandId);
+            Assert.NotNull(controller.ViewBag.CatalogTypeId);
+            Assert.False((bool)controller.ViewBag.UseAzureStorage);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ValidModel_UpdatesAndRedirects()
+        {
+            var controller = CreateController();
+            var item = new CatalogItem { Id = 3, Name = "Updated" };
+
+            var result = await controller.Edit(item);
+
+            var redirect = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+            _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+            _imageService.Verify(s => s.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Edit_Post_ValidModelWithTempImage_UpdatesImageAndItem()
+        {
+            var controller = CreateController();
+            var item = new CatalogItem { Id = 3, Name = "Updated", TempImageName = "/tmp/uploads/edit.png" };
+
+            var result = await controller.Edit(item);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("edit.png", item.PictureFileName);
+            _imageService.Verify(s => s.UpdateImageAsync(item), Times.Once);
+            _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+        }
+
+        [Fact]
+        public async Task Edit_Post_InvalidModel_ReturnsViewWithoutUpdating()
+        {
+            SetupBrandsAndTypes();
+            var controller = CreateController();
+            controller.ModelState.AddModelError("Name", "required");
+            var item = new CatalogItem { Id = 3, CatalogBrandId = 1, CatalogTypeId = 2 };
+
+            var result = await controller.Edit(item);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(item, view.Model);
+            _service.Verify(s => s.UpdateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_Get_NullId_ReturnsBadRequest()
+        {
+            var controller = CreateController();
+
+            var result = await controller.Delete(null);
+
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Get_UnknownId_ReturnsNotFound()
+        {
+            _service.Setup(s => s.FindCatalogItemAsync(11)).ReturnsAsync((CatalogItem?)null);
+            var controller = CreateController();
+
+            var result = await controller.Delete(11);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_Get_ExistingId_ReturnsViewWithItem()
+        {
+            var item = new CatalogItem { Id = 11, Name = "ToDelete" };
+            _service.Setup(s => s.FindCatalogItemAsync(11)).ReturnsAsync(item);
+            var controller = CreateController();
+
+            var result = await controller.Delete(11);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Same(item, view.Model);
+            Assert.Equal("/pics/x.png", item.PictureUri);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Extends `CatalogControllerTests.cs` with focused unit tests for the previously-uncovered actions/branches of `CatalogController`, driving the file to **100% line coverage (242/242)**.

All new tests are hermetic: `ICatalogService`, `IImageService`, `ICatalogConfiguration`, and `ILogger<CatalogController>` are mocked with Moq (following the existing file's conventions). No real DB/Azure/network. Existing cases are untouched.

New cases added:
- `Create()` GET — sets `ViewBag.CatalogBrandId/CatalogTypeId/UseAzureStorage` and returns a `CatalogItem` whose `PictureUri` comes from `_imageService.UrlDefaultImage()`.
- `Create(item)` POST invalid `ModelState` → returns `ViewResult` with the item, asserts `CreateCatalogItemAsync` is **not** called.
- `Create(item)` POST valid with non-empty `TempImageName` → sets `PictureFileName` (`Path.GetFileName`) and calls `UpdateImageAsync`.
- `Edit(id)` GET — null id (`BadRequest`), unknown id (`NotFound`), found (`ViewResult` with ViewBag set).
- `Edit(item)` POST — valid without temp image (redirect, `UpdateCatalogItemAsync` once, `UpdateImageAsync` never), valid with `TempImageName` (calls `UpdateImageAsync` + sets `PictureFileName`), invalid `ModelState` (returns `ViewResult`, no update).
- `Delete(id)` GET — null id (`BadRequest`), unknown id (`NotFound`), found (`ViewResult`).

GET actions build a `SelectList` from `GetCatalogBrandsAsync()`/`GetCatalogTypesAsync()`, so those mocks return small lists via a `SetupBrandsAndTypes()` helper.

## Verification
```
dotnet test  ->  Passed!  Failed: 0, Passed: 64, Skipped: 0, Total: 64
```
Coverage (cobertura) for the assigned class:
```
100.0%  242/242  Controllers/CatalogController.cs
```
No production code under `src/` was modified.

Link to Devin session: https://app.devin.ai/sessions/d7ead133bb384c559dbadbb3c7ed4391
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/40?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->