### PR TITLE
Test data layer (CatalogService, CatalogDBContext, HiLo generator) to 80%+

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Models/CatalogDBContextTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Models/CatalogDBContextTests.cs
@@ -1,0 +1,90 @@
+using eShopCoreModernized.Models;
+using eShopModernized.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace eShopModernized.Tests.Models
+{
+    public class CatalogDBContextTests
+    {
+        [Fact]
+        public void EnsureCreated_BuildsModel_WithConfiguredTableNames()
+        {
+            using var harness = new SqliteCatalogContext();
+            var model = harness.Context.Model;
+
+            Assert.Equal("Catalog", model.FindEntityType(typeof(CatalogItem))!.GetTableName());
+            Assert.Equal("CatalogBrand", model.FindEntityType(typeof(CatalogBrand))!.GetTableName());
+            Assert.Equal("CatalogType", model.FindEntityType(typeof(CatalogType))!.GetTableName());
+        }
+
+        [Fact]
+        public void CatalogItem_KeyAndRequiredColumns_AreConfigured()
+        {
+            using var harness = new SqliteCatalogContext();
+            var entity = harness.Context.Model.FindEntityType(typeof(CatalogItem))!;
+
+            Assert.Equal(nameof(CatalogItem.Id), entity.FindPrimaryKey()!.Properties.Single().Name);
+
+            var name = entity.FindProperty(nameof(CatalogItem.Name))!;
+            Assert.False(name.IsNullable);
+            Assert.Equal(50, name.GetMaxLength());
+
+            Assert.False(entity.FindProperty(nameof(CatalogItem.Price))!.IsNullable);
+            Assert.False(entity.FindProperty(nameof(CatalogItem.PictureFileName))!.IsNullable);
+        }
+
+        [Fact]
+        public void CatalogItem_PictureUri_IsIgnored()
+        {
+            using var harness = new SqliteCatalogContext();
+            var entity = harness.Context.Model.FindEntityType(typeof(CatalogItem))!;
+
+            Assert.Null(entity.FindProperty(nameof(CatalogItem.PictureUri)));
+        }
+
+        [Fact]
+        public void CatalogItem_HasRequiredForeignKeys_ToBrandAndType()
+        {
+            using var harness = new SqliteCatalogContext();
+            var entity = harness.Context.Model.FindEntityType(typeof(CatalogItem))!;
+
+            var foreignKeys = entity.GetForeignKeys().ToList();
+            Assert.Contains(foreignKeys, fk => fk.PrincipalEntityType.ClrType == typeof(CatalogBrand) && fk.IsRequired);
+            Assert.Contains(foreignKeys, fk => fk.PrincipalEntityType.ClrType == typeof(CatalogType) && fk.IsRequired);
+        }
+
+        [Fact]
+        public void Brand_And_Type_HaveMaxLengthConstraints()
+        {
+            using var harness = new SqliteCatalogContext();
+            var model = harness.Context.Model;
+
+            var brand = model.FindEntityType(typeof(CatalogBrand))!.FindProperty(nameof(CatalogBrand.Brand))!;
+            var type = model.FindEntityType(typeof(CatalogType))!.FindProperty(nameof(CatalogType.Type))!;
+
+            Assert.Equal(100, brand.GetMaxLength());
+            Assert.False(brand.IsNullable);
+            Assert.Equal(100, type.GetMaxLength());
+            Assert.False(type.IsNullable);
+        }
+
+        [Fact]
+        public void DbSets_PersistAndQueryThroughRelationalPipeline()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+
+            var item = harness.Context.CatalogItems
+                .Include(i => i.CatalogBrand)
+                .Include(i => i.CatalogType)
+                .Single(i => i.Id == 1);
+
+            Assert.Equal(".NET Bot Black Hoodie", item.Name);
+            Assert.Equal(".NET", item.CatalogBrand!.Brand);
+            Assert.Equal("T-Shirt", item.CatalogType!.Type);
+            Assert.Equal(5, harness.Context.CatalogItems.Count());
+            Assert.Equal(2, harness.Context.CatalogBrands.Count());
+            Assert.Equal(2, harness.Context.CatalogTypes.Count());
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Models/CatalogItemHiLoGeneratorTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Models/CatalogItemHiLoGeneratorTests.cs
@@ -1,0 +1,84 @@
+using eShopCoreModernized.Models;
+using eShopModernized.Tests.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace eShopModernized.Tests.Models
+{
+    public class CatalogItemHiLoGeneratorTests
+    {
+        private const int SeedValue = 1000;
+
+        private static CatalogDBContext CreateContext(FakeSequenceConnection connection)
+        {
+            var options = new DbContextOptionsBuilder<CatalogDBContext>()
+                .UseSqlite(connection)
+                .Options;
+            return new CatalogDBContext(options);
+        }
+
+        [Fact]
+        public void GetNextSequenceValue_FirstCall_QueriesDatabaseForSequence()
+        {
+            var connection = new FakeSequenceConnection(SeedValue);
+            using var db = CreateContext(connection);
+            var generator = new CatalogItemHiLoGenerator();
+
+            var value = generator.GetNextSequenceValue(db);
+
+            Assert.Equal(SeedValue, value);
+            Assert.Equal(1, connection.ExecuteScalarCount);
+            Assert.Equal(1, connection.OpenCount);
+            Assert.Contains("NEXT VALUE FOR catalog_hilo", connection.LastCommandText);
+        }
+
+        [Fact]
+        public void GetNextSequenceValue_WithinBlock_IncrementsWithoutHittingDatabase()
+        {
+            var connection = new FakeSequenceConnection(SeedValue);
+            using var db = CreateContext(connection);
+            var generator = new CatalogItemHiLoGenerator();
+
+            var first = generator.GetNextSequenceValue(db);
+            var second = generator.GetNextSequenceValue(db);
+            var third = generator.GetNextSequenceValue(db);
+
+            Assert.Equal(SeedValue, first);
+            Assert.Equal(SeedValue + 1, second);
+            Assert.Equal(SeedValue + 2, third);
+            // Only the first call should reach the database for the current HiLo block.
+            Assert.Equal(1, connection.ExecuteScalarCount);
+        }
+
+        [Fact]
+        public void GetNextSequenceValue_ExhaustsBlock_QueriesDatabaseAgain()
+        {
+            var connection = new FakeSequenceConnection(SeedValue);
+            using var db = CreateContext(connection);
+            var generator = new CatalogItemHiLoGenerator();
+
+            // HiLoIncrement is 10: the 1st and 11th calls hit the DB.
+            var values = Enumerable.Range(0, 11).Select(_ => generator.GetNextSequenceValue(db)).ToList();
+
+            Assert.Equal(2, connection.ExecuteScalarCount);
+            Assert.Equal(SeedValue, values[0]);
+            Assert.Equal(SeedValue + 9, values[9]);
+            Assert.Equal(SeedValue, values[10]);
+        }
+
+        [Fact]
+        public async Task GetNextSequenceValueAsync_ReturnsSameSequenceAsSync()
+        {
+            var connection = new FakeSequenceConnection(SeedValue);
+            using var db = CreateContext(connection);
+            var generator = new CatalogItemHiLoGenerator();
+
+            var first = await generator.GetNextSequenceValueAsync(db);
+            var second = await generator.GetNextSequenceValueAsync(db);
+
+            Assert.Equal(SeedValue, first);
+            Assert.Equal(SeedValue + 1, second);
+            Assert.Equal(1, connection.ExecuteScalarCount);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceTests.cs
@@ -1,0 +1,207 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopModernized.Tests.TestSupport;
+using Xunit;
+
+namespace eShopModernized.Tests.Services
+{
+    public class CatalogServiceTests
+    {
+        private static CatalogService CreateService(SqliteCatalogContext harness)
+            => new CatalogService(harness.Context, new CatalogItemHiLoGenerator());
+
+        [Fact]
+        public void GetCatalogItemsPaginated_FirstPage_RespectsPageSizeAndIncludesRelations()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var page = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+            Assert.Equal(0, page.ActualPage);
+            Assert.Equal(2, page.ItemsPerPage);
+            Assert.Equal(5, page.TotalItems);
+            Assert.Equal(3, page.TotalPages);
+            var items = page.Data.ToList();
+            Assert.Equal(2, items.Count);
+            Assert.All(items, i => Assert.NotNull(i.CatalogBrand));
+            Assert.All(items, i => Assert.NotNull(i.CatalogType));
+        }
+
+        [Fact]
+        public void GetCatalogItemsPaginated_LastPage_ReturnsRemainingItems()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var page = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 2);
+
+            Assert.Single(page.Data);
+        }
+
+        [Fact]
+        public async Task GetCatalogItemsPaginatedAsync_ReturnsPagedResult()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var page = await service.GetCatalogItemsPaginatedAsync(pageSize: 10, pageIndex: 0);
+
+            Assert.Equal(5, page.Data.Count());
+            Assert.Equal(5, page.TotalItems);
+            Assert.Equal(1, page.TotalPages);
+        }
+
+        [Fact]
+        public void FindCatalogItem_ExistingId_ReturnsItemWithRelations()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var item = service.FindCatalogItem(1);
+
+            Assert.NotNull(item);
+            Assert.Equal(".NET Bot Black Hoodie", item!.Name);
+            Assert.Equal(".NET", item.CatalogBrand!.Brand);
+            Assert.Equal("T-Shirt", item.CatalogType!.Type);
+        }
+
+        [Fact]
+        public void FindCatalogItem_UnknownId_ReturnsNull()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            Assert.Null(service.FindCatalogItem(9999));
+        }
+
+        [Fact]
+        public async Task FindCatalogItemAsync_ExistingId_ReturnsItem()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var item = await service.FindCatalogItemAsync(2);
+
+            Assert.NotNull(item);
+            Assert.Equal(2, item!.Id);
+        }
+
+        [Fact]
+        public async Task FindCatalogItemAsync_UnknownId_ReturnsNull()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            Assert.Null(await service.FindCatalogItemAsync(9999));
+        }
+
+        [Fact]
+        public void GetCatalogTypes_ReturnsSeededTypes()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var types = service.GetCatalogTypes().ToList();
+
+            Assert.Equal(2, types.Count);
+            Assert.Contains(types, t => t.Type == "Mug");
+        }
+
+        [Fact]
+        public async Task GetCatalogTypesAsync_ReturnsSeededTypes()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var types = await service.GetCatalogTypesAsync();
+
+            Assert.Equal(2, types.Count());
+        }
+
+        [Fact]
+        public void GetCatalogBrands_ReturnsSeededBrands()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var brands = service.GetCatalogBrands().ToList();
+
+            Assert.Equal(2, brands.Count);
+            Assert.Contains(brands, b => b.Brand == "Azure");
+        }
+
+        [Fact]
+        public async Task GetCatalogBrandsAsync_ReturnsSeededBrands()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            var brands = await service.GetCatalogBrandsAsync();
+
+            Assert.Equal(2, brands.Count());
+        }
+
+        [Fact]
+        public void UpdateCatalogItem_ExistingItem_PersistsChanges()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+            var updated = new CatalogItem { Id = 1, Name = "Updated Name", Price = 99M, CatalogBrandId = 1, CatalogTypeId = 2, PictureFileName = "1.png" };
+
+            service.UpdateCatalogItem(updated);
+
+            var item = service.FindCatalogItem(1);
+            Assert.Equal("Updated Name", item!.Name);
+            Assert.Equal(99M, item.Price);
+        }
+
+        [Fact]
+        public async Task UpdateCatalogItemAsync_PersistsChanges()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+            var updated = new CatalogItem { Id = 2, Name = "Async Updated", Price = 5M, CatalogBrandId = 1, CatalogTypeId = 1, PictureFileName = "2.png" };
+
+            await service.UpdateCatalogItemAsync(updated);
+
+            Assert.Equal("Async Updated", service.FindCatalogItem(2)!.Name);
+        }
+
+        [Fact]
+        public void RemoveCatalogItem_ExistingItem_RemovesIt()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+            var item = service.FindCatalogItem(1)!;
+
+            service.RemoveCatalogItem(item);
+
+            Assert.Null(service.FindCatalogItem(1));
+        }
+
+        [Fact]
+        public async Task RemoveCatalogItemAsync_RemovesIt()
+        {
+            using var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+            var item = await service.FindCatalogItemAsync(3);
+
+            await service.RemoveCatalogItemAsync(item!);
+
+            Assert.Null(service.FindCatalogItem(3));
+        }
+
+        [Fact]
+        public void Dispose_DisposesUnderlyingContext()
+        {
+            var harness = SqliteCatalogContext.CreateSeeded();
+            var service = CreateService(harness);
+
+            service.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => harness.Context.CatalogItems.ToList());
+            harness.Dispose();
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/TestSupport/FakeSequenceConnection.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/TestSupport/FakeSequenceConnection.cs
@@ -1,0 +1,80 @@
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace eShopModernized.Tests.TestSupport
+{
+    /// <summary>
+    /// A minimal <see cref="DbConnection"/> whose commands return a configurable
+    /// integer from <see cref="DbCommand.ExecuteScalar"/>. Used to drive
+    /// <c>CatalogItemHiLoGenerator</c> without a real SQL Server sequence.
+    /// </summary>
+    internal sealed class FakeSequenceConnection : DbConnection
+    {
+        private readonly int _scalarValue;
+        private ConnectionState _state = ConnectionState.Closed;
+
+        public int OpenCount { get; private set; }
+        public int ExecuteScalarCount { get; private set; }
+        public string? LastCommandText { get; private set; }
+
+        public FakeSequenceConnection(int scalarValue)
+        {
+            _scalarValue = scalarValue;
+        }
+
+        [AllowNull]
+        public override string ConnectionString { get; set; } = "DataSource=:memory:";
+        public override string Database => "fake";
+        public override string DataSource => ":memory:";
+        public override string ServerVersion => "0.0";
+        public override ConnectionState State => _state;
+
+        public override void ChangeDatabase(string databaseName) { }
+        public override void Close() => _state = ConnectionState.Closed;
+
+        public override void Open()
+        {
+            OpenCount++;
+            _state = ConnectionState.Open;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+            => throw new NotSupportedException();
+
+        protected override DbCommand CreateDbCommand() => new FakeCommand(this);
+
+        private object OnExecuteScalar(string? commandText)
+        {
+            ExecuteScalarCount++;
+            LastCommandText = commandText;
+            return _scalarValue;
+        }
+
+        private sealed class FakeCommand : DbCommand
+        {
+            private readonly FakeSequenceConnection _owner;
+
+            public FakeCommand(FakeSequenceConnection owner) => _owner = owner;
+
+            [AllowNull]
+            public override string CommandText { get; set; } = string.Empty;
+            public override int CommandTimeout { get; set; }
+            public override CommandType CommandType { get; set; }
+            public override bool DesignTimeVisible { get; set; }
+            public override UpdateRowSource UpdatedRowSource { get; set; }
+            [AllowNull]
+            protected override DbConnection? DbConnection { get; set; }
+            protected override DbParameterCollection DbParameterCollection => throw new NotSupportedException();
+            protected override DbTransaction? DbTransaction { get; set; }
+
+            public override void Cancel() { }
+            public override int ExecuteNonQuery() => 0;
+            public override object ExecuteScalar() => _owner.OnExecuteScalar(CommandText);
+            public override void Prepare() { }
+            protected override DbParameter CreateDbParameter() => throw new NotSupportedException();
+            protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/TestSupport/SqliteCatalogContext.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/TestSupport/SqliteCatalogContext.cs
@@ -1,0 +1,70 @@
+using eShopCoreModernized.Models;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests.TestSupport
+{
+    /// <summary>
+    /// Owns a SQLite in-memory connection together with a <see cref="CatalogDBContext"/>
+    /// created over it. The connection is kept open for the lifetime of the instance so
+    /// the in-memory database survives across context operations.
+    /// </summary>
+    internal sealed class SqliteCatalogContext : IDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        public CatalogDBContext Context { get; }
+
+        public SqliteCatalogContext()
+        {
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+
+            var options = new DbContextOptionsBuilder<CatalogDBContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            Context = new CatalogDBContext(options);
+            Context.Database.EnsureCreated();
+        }
+
+        public static SqliteCatalogContext CreateSeeded()
+        {
+            var harness = new SqliteCatalogContext();
+            harness.Seed();
+            return harness;
+        }
+
+        public void Seed()
+        {
+            var brands = new[]
+            {
+                new CatalogBrand { Id = 1, Brand = ".NET" },
+                new CatalogBrand { Id = 2, Brand = "Azure" },
+            };
+            var types = new[]
+            {
+                new CatalogType { Id = 1, Type = "Mug" },
+                new CatalogType { Id = 2, Type = "T-Shirt" },
+            };
+            Context.CatalogBrands.AddRange(brands);
+            Context.CatalogTypes.AddRange(types);
+            Context.CatalogItems.AddRange(
+                new CatalogItem { Id = 1, Name = ".NET Bot Black Hoodie", Price = 19.5M, CatalogBrandId = 1, CatalogTypeId = 2, PictureFileName = "1.png" },
+                new CatalogItem { Id = 2, Name = ".NET Black & White Mug", Price = 8.5M, CatalogBrandId = 1, CatalogTypeId = 1, PictureFileName = "2.png" },
+                new CatalogItem { Id = 3, Name = "Prism White T-Shirt", Price = 12M, CatalogBrandId = 2, CatalogTypeId = 2, PictureFileName = "3.png" },
+                new CatalogItem { Id = 4, Name = "Azure Mug", Price = 9M, CatalogBrandId = 2, CatalogTypeId = 1, PictureFileName = "4.png" },
+                new CatalogItem { Id = 5, Name = "Azure Black Hoodie", Price = 22M, CatalogBrandId = 2, CatalogTypeId = 2, PictureFileName = "5.png" });
+            Context.SaveChanges();
+
+            // Detach everything so reads exercise the real query pipeline (Include, etc.).
+            Context.ChangeTracker.Clear();
+        }
+
+        public void Dispose()
+        {
+            Context.Dispose();
+            _connection.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds focused, hermetic unit tests for the three .NET 8 catalog data-layer classes, driving each to ≥80% line coverage with no real SQL Server / Azure / network.

Coverage achieved (coverlet cobertura, `eShopCoreModernized`):
- `Models/CatalogDBContext.cs` — **100%** (106/106)
- `Models/CatalogItemHiLoGenerator.cs` — **100%** (46/46)
- `Services/CatalogService.cs` — **87.8%** (144/164)

Full suite: **78 passed / 0 failed** (52 pre-existing + 26 new).

New files (test project only; no production code touched, `*.csproj` untouched):
- `Services/CatalogServiceTests.cs`
- `Models/CatalogDBContextTests.cs`
- `Models/CatalogItemHiLoGeneratorTests.cs`
- `TestSupport/SqliteCatalogContext.cs` — owns an open **SQLite in-memory** connection + a real `CatalogDBContext`, seeds brands/types/items, `EnsureCreated()`.
- `TestSupport/FakeSequenceConnection.cs` — minimal `DbConnection`/`DbCommand` whose `ExecuteScalar()` returns a configurable int.

### How each class is exercised
**CatalogDBContext** — building/using a real SQLite-backed context runs `OnModelCreating` and all three `ConfigureCatalog*` methods. Tests assert table names (`Catalog`/`CatalogBrand`/`CatalogType`), keys, required + max-length columns, `PictureUri` ignored, required FKs to brand/type, and round-trip persistence via the relational pipeline (`Include`).

**CatalogService** — backed by the real SQLite context; covers sync + async variants of paginated (first/last page, relations included), find (hit/miss), get types, get brands, update, remove, and `Dispose` (asserts underlying context is disposed).

**CatalogItemHiLoGenerator** — the generator only needs `db.Database.GetDbConnection()` → `Open()` → `CreateCommand().ExecuteScalar()`. A `CatalogDBContext` is configured with `UseSqlite(FakeSequenceConnection)` so the raw `SELECT NEXT VALUE FOR catalog_hilo` call returns a stub int. Both branches are covered:
```
call #1  -> remainningLoIds == 0 -> ExecuteScalar (DB hit), returns seed
calls #2..#10 -> remainningLoIds-- -> ++sequenceId (no DB hit)
call #11 -> block exhausted -> ExecuteScalar again
```
plus `GetNextSequenceValueAsync` (the `Task.Run` wrapper).

### Why CatalogService isn't 100%
The only uncovered lines are `CreateCatalogItem` / `CreateCatalogItemAsync`. They call `indexGenerator.GetNextSequenceValue(db)`, which executes the SQL-Server-specific `SELECT NEXT VALUE FOR catalog_hilo` against the context's own connection. SQLite/EF-InMemory cannot emulate SQL Server sequences, and `CatalogItemHiLoGenerator.GetNextSequenceValue` is **not virtual**, so it can't be substituted with a stub without modifying production code (out of scope per the assignment). The HiLo logic itself is fully covered in isolation via `FakeSequenceConnection`. The remaining `Create` paths (Add + SaveChanges) would require a real SQL Server. This keeps `CatalogService` at 87.8% — above the 80% bar.


Link to Devin session: https://app.devin.ai/sessions/07e8c0a50de74fd69d3abf05676a3ebe
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/44?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->