### PR TITLE
Add Brand & Type filtering to catalog table

### DIFF
--- a/eShopModernized/src/eShopCoreModernized/Controllers/CatalogController.cs
+++ b/eShopModernized/src/eShopCoreModernized/Controllers/CatalogController.cs
@@ -26,11 +26,17 @@ namespace eShopCoreModernized.Controllers
             _logger = logger;
         }
 
-        public async Task<IActionResult> Index(int pageSize = 10, int pageIndex = 0)
+        public async Task<IActionResult> Index(int pageSize = 10, int pageIndex = 0, int? brandFilterApplied = null, int? typeFilterApplied = null)
         {
-            _logger.LogInformation("Now loading... /Catalog/Index?pageSize={PageSize}&pageIndex={PageIndex}", pageSize, pageIndex);
-            var paginatedItems = await _service.GetCatalogItemsPaginatedAsync(pageSize, pageIndex);
+            _logger.LogInformation("Now loading... /Catalog/Index?pageSize={PageSize}&pageIndex={PageIndex}&brand={Brand}&type={Type}", pageSize, pageIndex, brandFilterApplied, typeFilterApplied);
+            var paginatedItems = await _service.GetCatalogItemsPaginatedAsync(pageSize, pageIndex, brandFilterApplied, typeFilterApplied);
             ChangeUriPlaceholder(paginatedItems.Data);
+
+            ViewBag.BrandFilterApplied = brandFilterApplied;
+            ViewBag.TypeFilterApplied = typeFilterApplied;
+            ViewBag.Brands = await _service.GetCatalogBrandsAsync();
+            ViewBag.Types = await _service.GetCatalogTypesAsync();
+
             return View(paginatedItems);
         }
 

--- a/eShopModernized/src/eShopCoreModernized/Services/CatalogService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/CatalogService.cs
@@ -15,11 +15,22 @@ namespace eShopCoreModernized.Services
             this.indexGenerator = indexGenerator;
         }
 
-        public async Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex)
+        public async Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null)
         {
-            var totalItems = await db.CatalogItems.LongCountAsync();
+            var query = db.CatalogItems.AsQueryable();
 
-            var itemsOnPage = await db.CatalogItems
+            if (brandIdFilter.HasValue)
+            {
+                query = query.Where(c => c.CatalogBrandId == brandIdFilter.Value);
+            }
+            if (typeIdFilter.HasValue)
+            {
+                query = query.Where(c => c.CatalogTypeId == typeIdFilter.Value);
+            }
+
+            var totalItems = await query.LongCountAsync();
+
+            var itemsOnPage = await query
                 .Include(c => c.CatalogBrand)
                 .Include(c => c.CatalogType)
                 .OrderBy(c => c.Id)
@@ -31,11 +42,22 @@ namespace eShopCoreModernized.Services
                 pageIndex, pageSize, totalItems, itemsOnPage);
         }
 
-        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex)
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null)
         {
-            var totalItems = db.CatalogItems.LongCount();
+            var query = db.CatalogItems.AsQueryable();
 
-            var itemsOnPage = db.CatalogItems
+            if (brandIdFilter.HasValue)
+            {
+                query = query.Where(c => c.CatalogBrandId == brandIdFilter.Value);
+            }
+            if (typeIdFilter.HasValue)
+            {
+                query = query.Where(c => c.CatalogTypeId == typeIdFilter.Value);
+            }
+
+            var totalItems = query.LongCount();
+
+            var itemsOnPage = query
                 .Include(c => c.CatalogBrand)
                 .Include(c => c.CatalogType)
                 .OrderBy(c => c.Id)

--- a/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/CatalogServiceMock.cs
@@ -44,15 +44,27 @@ namespace eShopCoreModernized.Services
             }
         }
 
-        public Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex)
+        public Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null)
         {
-            return Task.FromResult(GetCatalogItemsPaginated(pageSize, pageIndex));
+            return Task.FromResult(GetCatalogItemsPaginated(pageSize, pageIndex, brandIdFilter, typeIdFilter));
         }
 
-        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex)
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null)
         {
-            var totalItems = catalogItems.Count;
-            var itemsOnPage = catalogItems
+            var filtered = catalogItems.AsEnumerable();
+
+            if (brandIdFilter.HasValue)
+            {
+                filtered = filtered.Where(c => c.CatalogBrandId == brandIdFilter.Value);
+            }
+            if (typeIdFilter.HasValue)
+            {
+                filtered = filtered.Where(c => c.CatalogTypeId == typeIdFilter.Value);
+            }
+
+            var filteredList = filtered.ToList();
+            var totalItems = filteredList.Count;
+            var itemsOnPage = filteredList
                 .Skip(pageSize * pageIndex)
                 .Take(pageSize)
                 .ToList();

--- a/eShopModernized/src/eShopCoreModernized/Services/ICatalogService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/ICatalogService.cs
@@ -9,8 +9,8 @@ namespace eShopCoreModernized.Services
         CatalogItem? FindCatalogItem(int id);
         Task<IEnumerable<CatalogBrand>> GetCatalogBrandsAsync();
         IEnumerable<CatalogBrand> GetCatalogBrands();
-        Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex);
-        PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex);
+        Task<PaginatedItemsViewModel<CatalogItem>> GetCatalogItemsPaginatedAsync(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null);
+        PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, int? brandIdFilter = null, int? typeIdFilter = null);
         Task<IEnumerable<CatalogType>> GetCatalogTypesAsync();
         IEnumerable<CatalogType> GetCatalogTypes();
         Task CreateCatalogItemAsync(CatalogItem catalogItem);

--- a/eShopModernized/src/eShopCoreModernized/Views/Catalog/Index.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Catalog/Index.cshtml
@@ -2,9 +2,43 @@
 
 @{
     ViewBag.Title = "Index";
+    var brands = (IEnumerable<eShopCoreModernized.Models.CatalogBrand>)ViewBag.Brands;
+    var types = (IEnumerable<eShopCoreModernized.Models.CatalogType>)ViewBag.Types;
+    int? brandFilterApplied = ViewBag.BrandFilterApplied;
+    int? typeFilterApplied = ViewBag.TypeFilterApplied;
 }
 
 <div class="esh-table">
+    <div class="container">
+        <form asp-action="Index" method="get" class="esh-catalog-filters row" style="margin-bottom: 20px; display: flex; align-items: center; gap: 15px;">
+            <div>
+                <label for="brandFilterApplied"><strong>Brand:</strong></label>
+                <select name="brandFilterApplied" id="brandFilterApplied" class="form-control" style="display: inline-block; width: auto; min-width: 150px;">
+                    <option value="">All</option>
+                    @foreach (var brand in brands)
+                    {
+                        <option value="@brand.Id" selected="@(brandFilterApplied == brand.Id ? "selected" : null)">@brand.Brand</option>
+                    }
+                </select>
+            </div>
+            <div>
+                <label for="typeFilterApplied"><strong>Type:</strong></label>
+                <select name="typeFilterApplied" id="typeFilterApplied" class="form-control" style="display: inline-block; width: auto; min-width: 150px;">
+                    <option value="">All</option>
+                    @foreach (var type in types)
+                    {
+                        <option value="@type.Id" selected="@(typeFilterApplied == type.Id ? "selected" : null)">@type.Type</option>
+                    }
+                </select>
+            </div>
+            <div>
+                <input type="hidden" name="pageSize" value="@Model.ItemsPerPage" />
+                <button type="submit" class="btn esh-button esh-button-primary">Filter</button>
+                <a asp-action="Index" class="btn esh-button" style="margin-left: 5px;">Reset</a>
+            </div>
+        </form>
+    </div>
+
     <p class="esh-link-wrapper">
         @Html.ActionLink("Create New", "Create", null, new { @class = "btn esh-button esh-button-primary" })
     </p>
@@ -18,11 +52,11 @@
 
                     @if (Model.ActualPage > 0)
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, brandFilterApplied = brandFilterApplied, typeFilterApplied = typeFilterApplied }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, brandFilterApplied = brandFilterApplied, typeFilterApplied = typeFilterApplied }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
                     <span class="esh-pager-item">
@@ -31,11 +65,11 @@
 
                     @if (Model.ActualPage < Model.TotalPages - 1)
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, brandFilterApplied = brandFilterApplied, typeFilterApplied = typeFilterApplied }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, brandFilterApplied = brandFilterApplied, typeFilterApplied = typeFilterApplied }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
             </nav>


### PR DESCRIPTION
## Summary

Adds Brand and Type dropdown filters to the eShopModernized catalog index page, allowing users to filter the product table by catalog brand and/or type.

Key changes:

- `ICatalogService.GetCatalogItemsPaginated[Async]` now accepts optional `int? brandIdFilter, int? typeIdFilter` params
- `CatalogService` applies `.Where(c => c.CatalogBrandId == ...)` / `.Where(c => c.CatalogTypeId == ...)` before pagination
- `CatalogServiceMock` mirrors the same filtering logic in-memory
- `CatalogController.Index` accepts `brandFilterApplied` and `typeFilterApplied` query params, passes `ViewBag.Brands`/`ViewBag.Types` lists to the view
- `Index.cshtml` renders a form with two `<select>` dropdowns (Brand, Type) + Filter/Reset buttons; pagination links preserve the active filter state

Link to Devin session: https://app.devin.ai/sessions/47232c1db48a4f88b899117b7c3ec199
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/45?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->