### PR TITLE
Add xUnit test project for eShopCoreModernized (80%+ line coverage)

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/Common/InMemoryContext.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Common/InMemoryContext.cs
@@ -1,0 +1,31 @@
+using eShopCoreModernized.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests.Common;
+
+/// <summary>
+/// Builds <see cref="CatalogDBContext"/> instances backed by the EF Core
+/// in-memory provider. Fast and hermetic – no external database required.
+/// </summary>
+public static class InMemoryContext
+{
+    public static CatalogDBContext Create(string? databaseName = null)
+    {
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase(databaseName ?? Guid.NewGuid().ToString())
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        return new CatalogDBContext(options);
+    }
+
+    public static CatalogDBContext CreateSeeded(string? databaseName = null)
+    {
+        var context = Create(databaseName);
+        context.CatalogBrands.AddRange(TestData.Brands());
+        context.CatalogTypes.AddRange(TestData.Types());
+        context.CatalogItems.AddRange(TestData.Items());
+        context.SaveChanges();
+        return context;
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Common/MvcTestContext.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Common/MvcTestContext.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace eShopModernized.Tests.Common;
+
+/// <summary>
+/// Helpers for wiring up the minimum MVC infrastructure a <see cref="Controller"/>
+/// needs in unit tests: an <see cref="HttpContext"/>, request services (for
+/// authentication extension methods), <c>ViewData</c>/<c>ViewBag</c> and
+/// <c>TempData</c>.
+/// </summary>
+public static class MvcTestContext
+{
+    public static void Configure(Controller controller, IAuthenticationService? authenticationService = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IModelMetadataProvider, EmptyModelMetadataProvider>();
+
+        var urlHelper = new Mock<IUrlHelper>();
+        var urlHelperFactory = new Mock<IUrlHelperFactory>();
+        urlHelperFactory.Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>())).Returns(urlHelper.Object);
+        services.AddSingleton(urlHelperFactory.Object);
+
+        if (authenticationService != null)
+        {
+            services.AddSingleton(authenticationService);
+        }
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        controller.ViewData = new ViewDataDictionary(
+            new EmptyModelMetadataProvider(),
+            new ModelStateDictionary());
+
+        controller.TempData = new TempDataDictionary(httpContext, new TestTempDataProvider());
+    }
+
+    private sealed class TestTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object> LoadTempData(HttpContext context) => new Dictionary<string, object>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object> values)
+        {
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Common/SqlServerFixture.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Common/SqlServerFixture.cs
@@ -1,0 +1,153 @@
+using System.Text.RegularExpressions;
+using eShopCoreModernized.Models;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace eShopModernized.Tests.Common;
+
+/// <summary>
+/// xUnit fixture that provisions a throw-away SQL Server database for the tests
+/// that exercise SQL-Server-specific code paths (the HiLo sequence used by
+/// <c>CatalogItemHiLoGenerator</c> and <c>CatalogService.CreateCatalogItem</c>).
+///
+/// These paths cannot run on the EF Core in-memory or SQLite providers because
+/// they issue the T-SQL statement <c>SELECT NEXT VALUE FOR catalog_hilo</c>.
+///
+/// If no SQL Server is reachable the fixture reports <see cref="Available"/> =
+/// <c>false</c> and the dependent tests skip cleanly, so <c>dotnet test</c>
+/// still passes in environments without a database. Point the tests at a server
+/// by setting the <c>TEST_SQL_CONNECTION</c> environment variable; otherwise a
+/// local instance on <c>localhost,1433</c> is assumed.
+/// </summary>
+public sealed class SqlServerFixture : IDisposable
+{
+    private const string SequenceName = "catalog_hilo";
+
+    public bool Available { get; }
+    public string? SkipReason { get; }
+
+    private readonly string? _databaseName;
+    private readonly string? _masterConnectionString;
+    private readonly string? _databaseConnectionString;
+
+    public SqlServerFixture()
+    {
+        var baseConnection = Environment.GetEnvironmentVariable("TEST_SQL_CONNECTION")
+            ?? "Server=127.0.0.1,1433;User Id=sa;Password=Str0ng!Passw0rd;TrustServerCertificate=True;Encrypt=False;Connect Timeout=5";
+
+        try
+        {
+            var masterBuilder = new SqlConnectionStringBuilder(baseConnection) { InitialCatalog = "master" };
+            _masterConnectionString = masterBuilder.ConnectionString;
+
+            using (var connection = new SqlConnection(_masterConnectionString))
+            {
+                connection.Open();
+            }
+
+            _databaseName = $"eShopTest_{Guid.NewGuid():N}";
+            var dbBuilder = new SqlConnectionStringBuilder(baseConnection) { InitialCatalog = _databaseName };
+            _databaseConnectionString = dbBuilder.ConnectionString;
+
+            CreateDatabase();
+            InitializeSchema();
+
+            Available = true;
+        }
+        catch (Exception ex)
+        {
+            Available = false;
+            SkipReason = $"SQL Server not available: {ex.Message}";
+        }
+    }
+
+    public CatalogDBContext CreateContext()
+    {
+        if (_databaseConnectionString is null)
+        {
+            throw new InvalidOperationException("SQL Server fixture is not available.");
+        }
+
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseSqlServer(_databaseConnectionString)
+            .Options;
+
+        return new CatalogDBContext(options);
+    }
+
+    private void CreateDatabase()
+    {
+        ExecuteMaster($"CREATE DATABASE [{_databaseName}];");
+    }
+
+    private void InitializeSchema()
+    {
+        using var context = CreateContext();
+
+        // The EF create script marks int primary keys as IDENTITY. The real
+        // catalog schema instead assigns CatalogItem ids from the HiLo sequence,
+        // so strip IDENTITY to allow explicit id inserts on the Catalog table
+        // (and to let the seed data below use explicit brand/type ids).
+        var script = context.Database.GenerateCreateScript();
+        script = Regex.Replace(script, @"\s+IDENTITY(\(\d+,\s*\d+\))?", string.Empty);
+
+        foreach (var batch in SplitSqlBatches(script))
+        {
+            context.Database.ExecuteSqlRaw(batch);
+        }
+
+        // The HiLo generator relies on a SQL Server sequence that is not part of
+        // the EF model, so create it explicitly.
+        context.Database.ExecuteSqlRaw(
+            $"CREATE SEQUENCE {SequenceName} AS int START WITH 1 INCREMENT BY 1;");
+
+        context.CatalogBrands.AddRange(TestData.Brands());
+        context.CatalogTypes.AddRange(TestData.Types());
+        context.SaveChanges();
+    }
+
+    private static IEnumerable<string> SplitSqlBatches(string script)
+    {
+        foreach (var batch in Regex.Split(script, @"^\s*GO\s*$", RegexOptions.Multiline))
+        {
+            if (!string.IsNullOrWhiteSpace(batch))
+            {
+                yield return batch;
+            }
+        }
+    }
+
+    private void ExecuteMaster(string sql)
+    {
+        using var connection = new SqlConnection(_masterConnectionString);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    public void Dispose()
+    {
+        if (!Available || _databaseName is null)
+        {
+            return;
+        }
+
+        try
+        {
+            ExecuteMaster(
+                $"ALTER DATABASE [{_databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{_databaseName}];");
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class SqlServerCollection : ICollectionFixture<SqlServerFixture>
+{
+    public const string Name = "SqlServer";
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Common/TestData.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Common/TestData.cs
@@ -1,0 +1,31 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests.Common;
+
+/// <summary>
+/// Factory helpers that build fresh, unattached model instances for tests.
+/// Each call returns new objects so that seeding multiple EF contexts does not
+/// trigger "instance already tracked" errors.
+/// </summary>
+public static class TestData
+{
+    public static List<CatalogBrand> Brands() => new()
+    {
+        new CatalogBrand { Id = 1, Brand = "Azure" },
+        new CatalogBrand { Id = 2, Brand = ".NET" },
+        new CatalogBrand { Id = 3, Brand = "Other" }
+    };
+
+    public static List<CatalogType> Types() => new()
+    {
+        new CatalogType { Id = 1, Type = "Mug" },
+        new CatalogType { Id = 2, Type = "T-Shirt" }
+    };
+
+    public static List<CatalogItem> Items() => new()
+    {
+        new CatalogItem { Id = 1, Name = "Item One", Description = "First", Price = 10m, PictureFileName = "1.png", CatalogTypeId = 1, CatalogBrandId = 1, AvailableStock = 5 },
+        new CatalogItem { Id = 2, Name = "Item Two", Description = "Second", Price = 20m, PictureFileName = "2.png", CatalogTypeId = 2, CatalogBrandId = 2, AvailableStock = 6 },
+        new CatalogItem { Id = 3, Name = "Item Three", Description = "Third", Price = 30m, PictureFileName = "3.png", CatalogTypeId = 1, CatalogBrandId = 3, AvailableStock = 7 }
+    };
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Configuration/CatalogConfigurationTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Configuration/CatalogConfigurationTests.cs
@@ -1,0 +1,81 @@
+using eShopCoreModernized.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace eShopModernized.Tests.Configuration;
+
+public class CatalogConfigurationTests
+{
+    private static CatalogConfiguration Build(Dictionary<string, string?> values)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        return new CatalogConfiguration(configuration);
+    }
+
+    [Fact]
+    public void BooleanFlags_ReflectConfiguredValues()
+    {
+        var config = Build(new Dictionary<string, string?>
+        {
+            ["AppSettings:UseMockData"] = "true",
+            ["AppSettings:UseAzureStorage"] = "true",
+            ["AppSettings:UseAzureManagedIdentity"] = "true",
+            ["AppSettings:UseCustomizationData"] = "true",
+            ["AppSettings:UseAzureActiveDirectory"] = "true"
+        });
+
+        Assert.True(config.UseMockData);
+        Assert.True(config.UseAzureStorage);
+        Assert.True(config.UseManagedIdentity);
+        Assert.True(config.UseCustomizationData);
+        Assert.True(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void BooleanFlags_DefaultToFalse_WhenMissing()
+    {
+        var config = Build(new Dictionary<string, string?>());
+
+        Assert.False(config.UseMockData);
+        Assert.False(config.UseAzureStorage);
+        Assert.False(config.UseManagedIdentity);
+        Assert.False(config.UseCustomizationData);
+        Assert.False(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void StringProperties_ReflectConfiguredValues()
+    {
+        var config = Build(new Dictionary<string, string?>
+        {
+            ["Azure:StorageConnectionString"] = "storage-cs",
+            ["Azure:ApplicationInsights:InstrumentationKey"] = "ikey",
+            ["Azure:ApplicationInsights:ConnectionString"] = "ai-cs",
+            ["Azure:ActiveDirectory:ClientId"] = "client-id",
+            ["Azure:ActiveDirectory:TenantId"] = "tenant-id",
+            ["Azure:ActiveDirectory:PostLogoutRedirectUri"] = "https://logout"
+        });
+
+        Assert.Equal("storage-cs", config.StorageConnectionString);
+        Assert.Equal("ikey", config.AppInsightsInstrumentationKey);
+        Assert.Equal("ai-cs", config.AppInsightsConnectionString);
+        Assert.Equal("client-id", config.AzureActiveDirectoryClientId);
+        Assert.Equal("tenant-id", config.AzureActiveDirectoryTenant);
+        Assert.Equal("https://logout", config.PostLogoutRedirectUri);
+    }
+
+    [Fact]
+    public void StringProperties_DefaultToEmpty_WhenMissing()
+    {
+        var config = Build(new Dictionary<string, string?>());
+
+        Assert.Equal(string.Empty, config.StorageConnectionString);
+        Assert.Equal(string.Empty, config.AppInsightsInstrumentationKey);
+        Assert.Equal(string.Empty, config.AppInsightsConnectionString);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryClientId);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryTenant);
+        Assert.Equal(string.Empty, config.PostLogoutRedirectUri);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/AccountControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/AccountControllerTests.cs
@@ -1,0 +1,132 @@
+using System.Security.Claims;
+using eShopCoreModernized.Controllers;
+using eShopModernized.Tests.Common;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class AccountControllerTests
+{
+    private static AccountController CreateController(Mock<IAuthenticationService>? auth = null, IUrlHelper? url = null)
+    {
+        var controller = new AccountController();
+        MvcTestContext.Configure(controller, (auth ?? new Mock<IAuthenticationService>()).Object);
+        if (url != null)
+        {
+            controller.Url = url;
+        }
+        return controller;
+    }
+
+    [Fact]
+    public void Login_Get_ReturnsView_AndSetsReturnUrl()
+    {
+        var controller = CreateController();
+
+        var result = controller.Login("/back");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("/back", controller.ViewData["ReturnUrl"]);
+    }
+
+    [Fact]
+    public async Task Login_Post_InvalidCredentials_ReturnsViewWithError()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Login(string.Empty, string.Empty, "/back");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("Invalid username or password", controller.ViewData["Error"]);
+        Assert.Equal("/back", controller.ViewData["ReturnUrl"]);
+    }
+
+    [Fact]
+    public async Task Login_Post_Valid_LocalReturnUrl_Redirects()
+    {
+        var auth = new Mock<IAuthenticationService>();
+        auth.Setup(a => a.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+            .Returns(Task.CompletedTask);
+
+        var url = new Mock<IUrlHelper>();
+        url.Setup(u => u.IsLocalUrl("/home")).Returns(true);
+
+        var controller = CreateController(auth, url.Object);
+
+        var result = await controller.Login("user", "pass", "/home");
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/home", redirect.Url);
+        auth.Verify(a => a.SignInAsync(It.IsAny<HttpContext>(), "Cookies",
+            It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_Post_Valid_NonLocalReturnUrl_RedirectsToCatalog()
+    {
+        var auth = new Mock<IAuthenticationService>();
+        auth.Setup(a => a.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+            .Returns(Task.CompletedTask);
+
+        var url = new Mock<IUrlHelper>();
+        url.Setup(u => u.IsLocalUrl(It.IsAny<string>())).Returns(false);
+
+        var controller = CreateController(auth, url.Object);
+
+        var result = await controller.Login("user", "pass", "http://evil.com");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+    }
+
+    [Fact]
+    public async Task Login_Post_Valid_NoReturnUrl_RedirectsToCatalog()
+    {
+        var auth = new Mock<IAuthenticationService>();
+        auth.Setup(a => a.SignInAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()))
+            .Returns(Task.CompletedTask);
+
+        var controller = CreateController(auth);
+
+        var result = await controller.Login("user", "pass");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+    }
+
+    [Fact]
+    public async Task Logout_SignsOut_AndRedirectsToCatalog()
+    {
+        var auth = new Mock<IAuthenticationService>();
+        auth.Setup(a => a.SignOutAsync(It.IsAny<HttpContext>(), It.IsAny<string>(),
+                It.IsAny<AuthenticationProperties>()))
+            .Returns(Task.CompletedTask);
+
+        var controller = CreateController(auth);
+
+        var result = await controller.Logout();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+        auth.Verify(a => a.SignOutAsync(It.IsAny<HttpContext>(), "Cookies",
+            It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public void AccessDenied_ReturnsView()
+    {
+        var controller = CreateController();
+
+        Assert.IsType<ViewResult>(controller.AccessDenied());
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/BrandsControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/BrandsControllerTests.cs
@@ -1,0 +1,77 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class BrandsControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<ILogger<BrandsController>> _logger = new();
+
+    private BrandsController CreateController() => new(_service.Object, _logger.Object);
+
+    private static List<CatalogBrand> Brands() => new()
+    {
+        new CatalogBrand { Id = 1, Brand = "Azure" },
+        new CatalogBrand { Id = 2, Brand = ".NET" }
+    };
+
+    [Fact]
+    public async Task Get_ReturnsOkWithAllBrands()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(Brands());
+
+        var result = await CreateController().Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var brands = Assert.IsAssignableFrom<IEnumerable<CatalogBrand>>(ok.Value);
+        Assert.Equal(2, brands.Count());
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOk_WhenBrandExists()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(Brands());
+
+        var result = await CreateController().Get(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var brand = Assert.IsType<CatalogBrand>(ok.Value);
+        Assert.Equal(1, brand.Id);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenBrandMissing()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(Brands());
+
+        var result = await CreateController().Get(99);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsOk_WhenBrandExists()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(Brands());
+
+        var result = await CreateController().Delete(2);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsNotFound_WhenBrandMissing()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(Brands());
+
+        var result = await CreateController().Delete(42);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/CatalogControllerTests.cs
@@ -1,0 +1,239 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.ViewModel;
+using eShopModernized.Tests.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class CatalogControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<IImageService> _imageService = new();
+    private readonly Mock<ICatalogConfiguration> _config = new();
+    private readonly Mock<ILogger<CatalogController>> _logger = new();
+
+    private CatalogController CreateController()
+    {
+        var controller = new CatalogController(_service.Object, _imageService.Object, _config.Object, _logger.Object);
+        MvcTestContext.Configure(controller);
+        return controller;
+    }
+
+    private void SetupLookups()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(TestData.Brands());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(TestData.Types());
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+    }
+
+    [Fact]
+    public async Task Index_ReturnsView_AndSetsPictureUri()
+    {
+        var items = TestData.Items();
+        _service.Setup(s => s.GetCatalogItemsPaginatedAsync(10, 0))
+            .ReturnsAsync(new PaginatedItemsViewModel<CatalogItem>(0, 10, items.Count, items));
+        _imageService.Setup(i => i.BuildUrlImage(It.IsAny<CatalogItem>())).Returns("/pics/x.png");
+
+        var result = await CreateController().Index();
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.IsType<PaginatedItemsViewModel<CatalogItem>>(view.Model);
+        _imageService.Verify(i => i.BuildUrlImage(It.IsAny<CatalogItem>()), Times.Exactly(items.Count));
+    }
+
+    [Fact]
+    public async Task Details_ReturnsBadRequest_WhenIdNull()
+    {
+        Assert.IsType<BadRequestResult>(await CreateController().Details(null));
+    }
+
+    [Fact]
+    public async Task Details_ReturnsNotFound_WhenMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync((CatalogItem?)null);
+
+        Assert.IsType<NotFoundResult>(await CreateController().Details(5));
+    }
+
+    [Fact]
+    public async Task Details_ReturnsView_WhenFound()
+    {
+        var item = TestData.Items().First();
+        _service.Setup(s => s.FindCatalogItemAsync(item.Id)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("/pics/1.png");
+
+        var view = Assert.IsType<ViewResult>(await CreateController().Details(item.Id));
+        Assert.Same(item, view.Model);
+        Assert.Equal("/pics/1.png", item.PictureUri);
+    }
+
+    [Fact]
+    public async Task Create_Get_ReturnsView_WithDefaultImage()
+    {
+        SetupLookups();
+        _imageService.Setup(i => i.UrlDefaultImage()).Returns("/pics/default.png");
+
+        var view = Assert.IsType<ViewResult>(await CreateController().Create());
+        var model = Assert.IsType<CatalogItem>(view.Model);
+        Assert.Equal("/pics/default.png", model.PictureUri);
+    }
+
+    [Fact]
+    public async Task Create_Post_Valid_WithTempImage_CreatesAndUpdatesImage()
+    {
+        var controller = CreateController();
+        var item = new CatalogItem { Name = "New", TempImageName = "/pics/temp/abc.png" };
+
+        var result = await controller.Create(item);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("abc.png", item.PictureFileName);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_Post_Valid_WithoutTempImage_DoesNotUpdateImage()
+    {
+        var controller = CreateController();
+        var item = new CatalogItem { Name = "New" };
+
+        var result = await controller.Create(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_Post_Invalid_ReturnsView()
+    {
+        SetupLookups();
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+        var item = new CatalogItem();
+
+        var view = Assert.IsType<ViewResult>(await controller.Create(item));
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.CreateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Get_ReturnsBadRequest_WhenIdNull()
+    {
+        Assert.IsType<BadRequestResult>(await CreateController().Edit((int?)null));
+    }
+
+    [Fact]
+    public async Task Edit_Get_ReturnsNotFound_WhenMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(9)).ReturnsAsync((CatalogItem?)null);
+        Assert.IsType<NotFoundResult>(await CreateController().Edit(9));
+    }
+
+    [Fact]
+    public async Task Edit_Get_ReturnsView_WhenFound()
+    {
+        SetupLookups();
+        var item = TestData.Items().First();
+        _service.Setup(s => s.FindCatalogItemAsync(item.Id)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("/pics/1.png");
+
+        var view = Assert.IsType<ViewResult>(await CreateController().Edit(item.Id));
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task Edit_Post_Valid_WithTempImage_UpdatesImageAndItem()
+    {
+        var controller = CreateController();
+        var item = new CatalogItem { Id = 1, Name = "Edited", TempImageName = "/pics/temp/new.png" };
+
+        var result = await controller.Edit(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("new.png", item.PictureFileName);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_Valid_WithoutTempImage_UpdatesItemOnly()
+    {
+        var controller = CreateController();
+        var item = new CatalogItem { Id = 1, Name = "Edited" };
+
+        var result = await controller.Edit(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_Post_Invalid_ReturnsView()
+    {
+        SetupLookups();
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+        var item = new CatalogItem { Id = 1 };
+
+        var view = Assert.IsType<ViewResult>(await controller.Edit(item));
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.UpdateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_ReturnsBadRequest_WhenIdNull()
+    {
+        Assert.IsType<BadRequestResult>(await CreateController().Delete((int?)null));
+    }
+
+    [Fact]
+    public async Task Delete_Get_ReturnsNotFound_WhenMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(3)).ReturnsAsync((CatalogItem?)null);
+        Assert.IsType<NotFoundResult>(await CreateController().Delete(3));
+    }
+
+    [Fact]
+    public async Task Delete_Get_ReturnsView_WhenFound()
+    {
+        var item = TestData.Items().First();
+        _service.Setup(s => s.FindCatalogItemAsync(item.Id)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("/pics/1.png");
+
+        var view = Assert.IsType<ViewResult>(await CreateController().Delete(item.Id));
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_RemovesItem_WhenFound()
+    {
+        var item = TestData.Items().First();
+        _service.Setup(s => s.FindCatalogItemAsync(item.Id)).ReturnsAsync(item);
+
+        var result = await CreateController().DeleteConfirmed(item.Id);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _service.Verify(s => s.RemoveCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_DoesNothing_WhenMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(50)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().DeleteConfirmed(50);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _service.Verify(s => s.RemoveCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/FilesControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/FilesControllerTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class FilesControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<ILogger<FilesController>> _logger = new();
+
+    [Fact]
+    public async Task Get_ReturnsJsonFile_WithSerializedBrands()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>
+        {
+            new() { Id = 1, Brand = "Azure" },
+            new() { Id = 2, Brand = ".NET" }
+        });
+
+        var controller = new FilesController(_service.Object, _logger.Object);
+
+        var result = await controller.Get();
+
+        var fileResult = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("application/json", fileResult.ContentType);
+
+        var dtos = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(fileResult.FileContents);
+        Assert.NotNull(dtos);
+        Assert.Equal(2, dtos!.Count);
+        Assert.Equal("Azure", dtos[0].Brand);
+    }
+
+    [Fact]
+    public void BrandDTO_ExposesIdAndBrand()
+    {
+        var dto = new FilesController.BrandDTO { Id = 7, Brand = "Contoso" };
+
+        Assert.Equal(7, dto.Id);
+        Assert.Equal("Contoso", dto.Brand);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/HealthControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/HealthControllerTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopModernized.Tests.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class HealthControllerTests
+{
+    private readonly Mock<ICatalogConfiguration> _config = new();
+    private readonly Mock<ILogger<HealthController>> _logger = new();
+
+    private static string Serialize(IActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        return JsonSerializer.Serialize(ok.Value);
+    }
+
+    [Fact]
+    public void Get_ReturnsHealthy()
+    {
+        var controller = new HealthController(_config.Object, InMemoryContext.Create(), _logger.Object);
+
+        var json = Serialize(controller.Get());
+
+        Assert.Contains("Healthy", json);
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReportsHealthyDatabase_WhenAzureStorageDisabled()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+        var controller = new HealthController(_config.Object, InMemoryContext.Create(), _logger.Object);
+
+        var json = Serialize(await controller.GetDetailed());
+
+        Assert.Contains("\"database\"", json);
+        Assert.Contains("Healthy", json);
+        Assert.DoesNotContain("azureStorage", json);
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReportsUnhealthyDatabase_WhenContextDisposed()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+        var context = InMemoryContext.Create();
+        context.Dispose();
+        var controller = new HealthController(_config.Object, context, _logger.Object);
+
+        var json = Serialize(await controller.GetDetailed());
+
+        Assert.Contains("Unhealthy", json);
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReportsNotConfigured_WhenAzureEnabledButNoClient()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+        var controller = new HealthController(_config.Object, InMemoryContext.Create(), _logger.Object, null);
+
+        var json = Serialize(await controller.GetDetailed());
+
+        Assert.Contains("NotConfigured", json);
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReportsUnhealthyStorage_WhenBlobClientThrows()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new RequestFailedException("no access"));
+
+        var blob = new Mock<BlobServiceClient>();
+        blob.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        var controller = new HealthController(_config.Object, InMemoryContext.Create(), _logger.Object, blob.Object);
+
+        var json = Serialize(await controller.GetDetailed());
+
+        Assert.Contains("Unhealthy", json);
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReportsHealthyStorage_WhenBlobClientResponds()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+
+        var properties = BlobsModelFactory.BlobContainerProperties(
+            lastModified: DateTimeOffset.UtcNow, eTag: new ETag("etag"));
+        var response = Response.FromValue(properties, Mock.Of<Response>());
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.GetPropertiesAsync(It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var blob = new Mock<BlobServiceClient>();
+        blob.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        var controller = new HealthController(_config.Object, InMemoryContext.Create(), _logger.Object, blob.Object);
+
+        var json = Serialize(await controller.GetDetailed());
+
+        Assert.Contains("Blob Storage", json);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/ImageUploadControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/ImageUploadControllerTests.cs
@@ -1,0 +1,88 @@
+using System.Text;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class ImageUploadControllerTests
+{
+    private readonly Mock<IImageService> _imageService = new();
+    private readonly Mock<ILogger<ImageUploadController>> _logger = new();
+
+    private ImageUploadController CreateController() => new(_imageService.Object, _logger.Object);
+
+    private static IFormFile CreateFormFile(string fileName, long length = 10, string contentType = "image/png")
+    {
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns(fileName);
+        file.SetupGet(f => f.Length).Returns(length);
+        file.SetupGet(f => f.ContentType).Returns(contentType);
+        file.Setup(f => f.OpenReadStream()).Returns(new MemoryStream(Encoding.UTF8.GetBytes("data")));
+        return file.Object;
+    }
+
+    [Fact]
+    public async Task UploadImage_ReturnsBadRequest_WhenFileNull()
+    {
+        var result = await CreateController().UploadImage(null!);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No file uploaded", bad.Value);
+    }
+
+    [Fact]
+    public async Task UploadImage_ReturnsBadRequest_WhenFileEmpty()
+    {
+        var result = await CreateController().UploadImage(CreateFormFile("a.png", length: 0));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UploadImage_ReturnsBadRequest_WhenExtensionNotAllowed()
+    {
+        var result = await CreateController().UploadImage(CreateFormFile("malware.exe"));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("Invalid file type", bad.Value!.ToString());
+    }
+
+    [Fact]
+    public async Task UploadImage_ReturnsOk_WhenValid()
+    {
+        _imageService.Setup(s => s.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()))
+            .ReturnsAsync("/pics/temp/a.png");
+
+        var result = await CreateController().UploadImage(CreateFormFile("a.png"), 5);
+
+        Assert.IsType<OkObjectResult>(result);
+        _imageService.Verify(s => s.UploadTempImageAsync(It.IsAny<IFormFile>(), 5), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadImage_Returns500_WhenServiceThrows()
+    {
+        _imageService.Setup(s => s.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await CreateController().UploadImage(CreateFormFile("a.png"));
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, status.StatusCode);
+    }
+
+    [Fact]
+    public void GetDefaultImage_ReturnsOk()
+    {
+        _imageService.Setup(s => s.UrlDefaultImage()).Returns("/pics/default.png");
+
+        var result = CreateController().GetDefaultImage();
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Controllers/PicControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Controllers/PicControllerTests.cs
@@ -1,0 +1,85 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Controllers;
+
+public class PicControllerTests : IDisposable
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<ILogger<PicController>> _logger = new();
+    private readonly Mock<IWebHostEnvironment> _environment = new();
+    private readonly string _webRoot;
+
+    public PicControllerTests()
+    {
+        _webRoot = Path.Combine(Path.GetTempPath(), "eshop-pic-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(_webRoot, "Pics"));
+        _environment.SetupGet(e => e.WebRootPath).Returns(_webRoot);
+        _environment.SetupGet(e => e.ContentRootPath).Returns(_webRoot);
+    }
+
+    private PicController CreateController() => new(_service.Object, _logger.Object, _environment.Object);
+
+    [Fact]
+    public async Task Index_ReturnsBadRequest_WhenIdNotPositive()
+    {
+        Assert.IsType<BadRequestResult>(await CreateController().Index(0));
+    }
+
+    [Fact]
+    public async Task Index_ReturnsNotFound_WhenItemMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(1)).ReturnsAsync((CatalogItem?)null);
+
+        Assert.IsType<NotFoundResult>(await CreateController().Index(1));
+    }
+
+    [Fact]
+    public async Task Index_ReturnsNotFound_WhenFileMissing()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(1))
+            .ReturnsAsync(new CatalogItem { Id = 1, PictureFileName = "missing.png" });
+
+        Assert.IsType<NotFoundResult>(await CreateController().Index(1));
+    }
+
+    [Fact]
+    public async Task Index_ReturnsFile_WhenFileExists()
+    {
+        var fileName = "1.png";
+        await File.WriteAllBytesAsync(Path.Combine(_webRoot, "Pics", fileName), new byte[] { 1, 2, 3 });
+        _service.Setup(s => s.FindCatalogItemAsync(1))
+            .ReturnsAsync(new CatalogItem { Id = 1, PictureFileName = fileName });
+
+        var result = await CreateController().Index(1);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/png", file.ContentType);
+        Assert.Equal(3, file.FileContents.Length);
+    }
+
+    [Fact]
+    public async Task Index_ReturnsFile_WithOctetStream_ForUnknownExtension()
+    {
+        var fileName = "1.xyz";
+        await File.WriteAllBytesAsync(Path.Combine(_webRoot, "Pics", fileName), new byte[] { 9 });
+        _service.Setup(s => s.FindCatalogItemAsync(2))
+            .ReturnsAsync(new CatalogItem { Id = 2, PictureFileName = fileName });
+
+        var result = await CreateController().Index(2);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("application/octet-stream", file.ContentType);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_webRoot, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Infrastructure/MigrationTelemetryInitializerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Infrastructure/MigrationTelemetryInitializerTests.cs
@@ -1,0 +1,24 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Channel;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Infrastructure;
+
+public class MigrationTelemetryInitializerTests
+{
+    [Fact]
+    public void Initialize_AddsMigrationGlobalProperties()
+    {
+        var context = new TelemetryContext();
+        var telemetry = new Mock<ITelemetry>();
+        telemetry.SetupGet(t => t.Context).Returns(context);
+
+        new MigrationTelemetryInitializer().Initialize(telemetry.Object);
+
+        Assert.Equal(".NET Core 6.0", context.GlobalProperties["ApplicationVersion"]);
+        Assert.Equal("StranglerFig-Complete", context.GlobalProperties["MigrationPhase"]);
+        Assert.Equal("Catalog-Core", context.GlobalProperties["ServiceType"]);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Infrastructure/SqlConnectionFactoryTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Infrastructure/SqlConnectionFactoryTests.cs
@@ -1,0 +1,51 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace eShopModernized.Tests.Infrastructure;
+
+public class SqlConnectionFactoryTests
+{
+    private const string ConnectionString =
+        "Server=tcp:localhost,1433;Database=CatalogDb;User Id=sa;Password=Passw0rd!;TrustServerCertificate=True";
+
+    private static IConfiguration BuildConfiguration(string? connectionString)
+    {
+        var values = new Dictionary<string, string?>();
+        if (connectionString != null)
+        {
+            values["ConnectionStrings:CatalogDBContext"] = connectionString;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreatesConnection_WithConfiguredConnectionString()
+    {
+        var factory = new AppSettingsSqlConnectionFactory(BuildConfiguration(ConnectionString));
+
+        using var connection = factory.CreateConnection();
+
+        Assert.Contains("Database=CatalogDb", connection.ConnectionString);
+    }
+
+    [Fact]
+    public void ManagedIdentityFactory_CanBeConstructed()
+    {
+        var factory = new ManagedIdentitySqlConnectionFactory(BuildConfiguration(ConnectionString));
+
+        Assert.NotNull(factory);
+    }
+
+    // Acquiring a managed-identity token requires a live Azure environment, so
+    // CreateConnection cannot complete here – it throws while requesting the
+    // token. This still exercises the connection-building code up to that point.
+    [Fact]
+    public void ManagedIdentityFactory_CreateConnection_ThrowsWithoutAzureIdentity()
+    {
+        var factory = new ManagedIdentitySqlConnectionFactory(BuildConfiguration(ConnectionString));
+
+        Assert.ThrowsAny<Exception>(() => factory.CreateConnection());
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Models/CatalogItemHiLoGeneratorTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Models/CatalogItemHiLoGeneratorTests.cs
@@ -1,0 +1,54 @@
+using eShopCoreModernized.Models;
+using eShopModernized.Tests.Common;
+using Xunit;
+
+namespace eShopModernized.Tests.Models;
+
+/// <summary>
+/// <see cref="CatalogItemHiLoGenerator"/> issues the T-SQL statement
+/// <c>SELECT NEXT VALUE FOR catalog_hilo</c>, which only runs against SQL Server.
+/// These tests use the <see cref="SqlServerFixture"/> and skip when no server is
+/// reachable.
+/// </summary>
+[Collection(SqlServerCollection.Name)]
+public class CatalogItemHiLoGeneratorTests
+{
+    private readonly SqlServerFixture _fixture;
+
+    public CatalogItemHiLoGeneratorTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [SkippableFact]
+    public void GetNextSequenceValue_ReturnsMonotonicallyIncreasingValues()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+
+        var generator = new CatalogItemHiLoGenerator();
+        using var context = _fixture.CreateContext();
+
+        // First call reads the sequence from the database; subsequent calls are
+        // served from the in-memory HiLo block (the "else" branch).
+        var first = generator.GetNextSequenceValue(context);
+        var second = generator.GetNextSequenceValue(context);
+        var third = generator.GetNextSequenceValue(context);
+
+        Assert.True(first > 0);
+        Assert.Equal(first + 1, second);
+        Assert.Equal(second + 1, third);
+    }
+
+    [SkippableFact]
+    public async Task GetNextSequenceValueAsync_ReturnsValue()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+
+        var generator = new CatalogItemHiLoGenerator();
+        using var context = _fixture.CreateContext();
+
+        var value = await generator.GetNextSequenceValueAsync(context);
+
+        Assert.True(value > 0);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Models/ModelsTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Models/ModelsTests.cs
@@ -1,0 +1,86 @@
+using eShopCoreModernized.Models;
+using Xunit;
+
+namespace eShopModernized.Tests.Models;
+
+public class ModelsTests
+{
+    [Fact]
+    public void CatalogBrand_StoresProperties()
+    {
+        var brand = new CatalogBrand { Id = 3, Brand = "Contoso" };
+
+        Assert.Equal(3, brand.Id);
+        Assert.Equal("Contoso", brand.Brand);
+    }
+
+    [Fact]
+    public void CatalogBrand_Brand_DefaultsToEmpty()
+    {
+        Assert.Equal(string.Empty, new CatalogBrand().Brand);
+    }
+
+    [Fact]
+    public void CatalogType_StoresProperties()
+    {
+        var type = new CatalogType { Id = 2, Type = "Mug" };
+
+        Assert.Equal(2, type.Id);
+        Assert.Equal("Mug", type.Type);
+    }
+
+    [Fact]
+    public void CatalogType_Type_DefaultsToEmpty()
+    {
+        Assert.Equal(string.Empty, new CatalogType().Type);
+    }
+
+    [Fact]
+    public void CatalogItem_Constructor_SetsDefaultPictureName()
+    {
+        Assert.Equal(CatalogItem.DefaultPictureName, new CatalogItem().PictureFileName);
+        Assert.Equal("dummy.png", CatalogItem.DefaultPictureName);
+    }
+
+    [Fact]
+    public void CatalogItem_StoresAllProperties()
+    {
+        var brand = new CatalogBrand { Id = 1, Brand = "Azure" };
+        var type = new CatalogType { Id = 1, Type = "Mug" };
+
+        var item = new CatalogItem
+        {
+            Id = 10,
+            Name = "Widget",
+            Description = "A widget",
+            Price = 42.50m,
+            PictureFileName = "10.png",
+            PictureUri = "/pics/10.png",
+            TempImageName = "/pics/temp/10.png",
+            CatalogTypeId = 1,
+            CatalogType = type,
+            CatalogBrandId = 1,
+            CatalogBrand = brand,
+            AvailableStock = 100,
+            RestockThreshold = 5,
+            MaxStockThreshold = 200,
+            OnReorder = true
+        };
+
+        Assert.Equal(10, item.Id);
+        Assert.Equal("Widget", item.Name);
+        Assert.Equal("A widget", item.Description);
+        Assert.Equal(42.50m, item.Price);
+        Assert.Equal("10.png", item.PictureFileName);
+        Assert.Equal("/pics/10.png", item.PictureUri);
+        Assert.Equal("/pics/temp/10.png", item.TempImageName);
+        Assert.Equal(1, item.CatalogTypeId);
+        Assert.Same(type, item.CatalogType);
+        Assert.Equal(1, item.CatalogBrandId);
+        Assert.Same(brand, item.CatalogBrand);
+        Assert.Equal(100, item.AvailableStock);
+        Assert.Equal(5, item.RestockThreshold);
+        Assert.Equal(200, item.MaxStockThreshold);
+        Assert.True(item.OnReorder);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/README.md
+++ b/eShopModernized/tests/eShopModernized.Tests/README.md
@@ -1,0 +1,113 @@
+# eShopModernized.Tests
+
+Unit tests for `eShopModernized/src/eShopCoreModernized` (the `eShopCoreModernized`
+ASP.NET Core 8.0 web app). Built with **xUnit**, **Moq**, and the **EF Core
+in-memory** provider, plus an optional throw-away **SQL Server** database for the
+code paths that depend on a real server.
+
+## Running the tests
+
+```bash
+cd eShopModernized/tests/eShopModernized.Tests
+dotnet test
+```
+
+All tests pass without any external infrastructure. The tests that need SQL
+Server (see below) skip automatically when no server is reachable.
+
+### SQL Server–dependent tests
+
+`CatalogItemHiLoGenerator` and `CatalogService.CreateCatalogItem[Async]` issue
+`SELECT NEXT VALUE FOR catalog_hilo`, which only runs on SQL Server (not on the
+in-memory / SQLite providers). `SqlServerFixture` provisions a temporary database
+for these tests and tears it down afterwards.
+
+By default it connects to `Server=127.0.0.1,1433` with the `sa` account. Point it
+elsewhere with the `TEST_SQL_CONNECTION` environment variable:
+
+```bash
+export TEST_SQL_CONNECTION="Server=127.0.0.1,1433;User Id=sa;Password=Str0ng!Passw0rd;TrustServerCertificate=True;Encrypt=False"
+dotnet test
+```
+
+A local server can be started with Docker:
+
+```bash
+docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Str0ng!Passw0rd" \
+  -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+```
+
+When no server is available these tests report as **skipped** (via
+`Xunit.SkippableFact`) and `dotnet test` still succeeds.
+
+## Coverage report
+
+```bash
+# collect coverage
+dotnet test --collect:"XPlat Code Coverage"
+
+# generate a per-class report (install the tool once)
+dotnet tool install -g dotnet-reportgenerator-globaltool
+export DOTNET_ROOT="$(dirname "$(which dotnet)")"
+reportgenerator \
+  -reports:"TestResults/**/coverage.cobertura.xml" \
+  -targetdir:"TestResults/report" \
+  -reporttypes:"TextSummary;Html"
+
+cat TestResults/report/Summary.txt
+```
+
+## Coverage status
+
+Line coverage is **≥ 80% for every testable class**. Latest run:
+
+| Class | Line coverage |
+| --- | --- |
+| `CatalogConfiguration` | 100% |
+| `AccountController` | 100% |
+| `BrandsController` | 100% |
+| `CatalogController` | 100% |
+| `FilesController` | 100% |
+| `HealthController` | 100% |
+| `ImageUploadController` | 100% |
+| `PicController` | 82% |
+| `AppSettingsSqlConnectionFactory` | 100% |
+| `ManagedIdentitySqlConnectionFactory` | 77% (see note) |
+| `MigrationTelemetryInitializer` | 100% |
+| `CatalogBrand` / `CatalogItem` / `CatalogType` | 100% |
+| `CatalogDBContext` | 100% |
+| `CatalogItemHiLoGenerator` | 100% |
+| `CatalogService` | 100% |
+| `CatalogServiceMock` | 100% |
+| `ImageAzureStorage` | 96% |
+| `ImageMockStorage` | 100% |
+| `PaginatedItemsViewModel<T>` | 100% |
+
+### Documented gaps requiring live infrastructure
+
+- **`ManagedIdentitySqlConnectionFactory` (77%)** — the final lines assign the
+  acquired AAD access token to the connection and return it. Reaching them
+  requires a *successful* `DefaultAzureCredential.GetToken` call, which only
+  works inside a live Azure / managed-identity environment. The test exercises
+  everything up to (and including) the token request; the credential-unavailable
+  path is asserted instead. The successful path cannot be unit-tested here.
+
+Classes reported at 0% that are **not** unit-testable and are intentionally
+excluded: `Program` (top-level web-host bootstrap) and the Razor
+`AspNetCoreGeneratedDocument.Views_*` view classes.
+
+## Layout
+
+```
+Common/           Shared test helpers
+  TestData.cs         Factory methods for brands / types / items
+  InMemoryContext.cs  Builds EF Core in-memory CatalogDBContext instances
+  SqlServerFixture.cs xUnit fixture for the SQL-Server-only tests (skippable)
+  MvcTestContext.cs   Wires up ControllerContext / RequestServices for controllers
+Controllers/      Controller tests (Groups A, B, C)
+Services/         Service tests (Group D)
+Configuration/    CatalogConfiguration tests (Group E)
+Models/           POCO model + HiLo generator tests (Group E)
+ViewModel/        PaginatedItemsViewModel tests (Group E)
+Infrastructure/   Telemetry + SqlConnectionFactory tests (Group E)
+```

--- a/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceMockTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceMockTests.cs
@@ -1,0 +1,137 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Xunit;
+
+namespace eShopModernized.Tests.Services;
+
+public class CatalogServiceMockTests
+{
+    private readonly CatalogServiceMock _service = new();
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsSeededBrands()
+    {
+        Assert.Equal(5, _service.GetCatalogBrands().Count());
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsSeededBrands()
+    {
+        Assert.Equal(5, (await _service.GetCatalogBrandsAsync()).Count());
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsSeededTypes()
+    {
+        Assert.Equal(4, _service.GetCatalogTypes().Count());
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsSeededTypes()
+    {
+        Assert.Equal(4, (await _service.GetCatalogTypesAsync()).Count());
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsRequestedPage()
+    {
+        var page = _service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 1);
+
+        Assert.Equal(5, page.TotalItems);
+        Assert.Equal(2, page.Data.Count());
+        Assert.Equal(1, page.ActualPage);
+    }
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_ReturnsRequestedPage()
+    {
+        var page = await _service.GetCatalogItemsPaginatedAsync(pageSize: 10, pageIndex: 0);
+
+        Assert.Equal(5, page.Data.Count());
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsItem_WhenExists()
+    {
+        Assert.NotNull(_service.FindCatalogItem(1));
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ReturnsNull_WhenMissing()
+    {
+        Assert.Null(await _service.FindCatalogItemAsync(999));
+    }
+
+    [Fact]
+    public void CreateCatalogItem_AddsItemWithNewId()
+    {
+        var item = new CatalogItem { Name = "New", CatalogBrandId = 1, CatalogTypeId = 1 };
+
+        _service.CreateCatalogItem(item);
+
+        Assert.Equal(6, item.Id);
+        Assert.NotNull(_service.FindCatalogItem(6));
+    }
+
+    [Fact]
+    public async Task CreateCatalogItemAsync_AddsItem()
+    {
+        var item = new CatalogItem { Name = "Async", CatalogBrandId = 1, CatalogTypeId = 1 };
+
+        await _service.CreateCatalogItemAsync(item);
+
+        Assert.NotNull(await _service.FindCatalogItemAsync(item.Id));
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_ReplacesExistingItem()
+    {
+        var updated = new CatalogItem { Id = 1, Name = "Renamed", CatalogBrandId = 1, CatalogTypeId = 1 };
+
+        _service.UpdateCatalogItem(updated);
+
+        Assert.Equal("Renamed", _service.FindCatalogItem(1)!.Name);
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_DoesNothing_WhenItemMissing()
+    {
+        var countBefore = _service.GetCatalogItemsPaginated(100, 0).Data.Count();
+
+        _service.UpdateCatalogItem(new CatalogItem { Id = 999, Name = "Ghost" });
+
+        Assert.Equal(countBefore, _service.GetCatalogItemsPaginated(100, 0).Data.Count());
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_ReplacesExistingItem()
+    {
+        var updated = new CatalogItem { Id = 2, Name = "AsyncRenamed", CatalogBrandId = 1, CatalogTypeId = 1 };
+
+        await _service.UpdateCatalogItemAsync(updated);
+
+        Assert.Equal("AsyncRenamed", (await _service.FindCatalogItemAsync(2))!.Name);
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_RemovesItem()
+    {
+        _service.RemoveCatalogItem(new CatalogItem { Id = 3 });
+
+        Assert.Null(_service.FindCatalogItem(3));
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_RemovesItem()
+    {
+        await _service.RemoveCatalogItemAsync(new CatalogItem { Id = 4 });
+
+        Assert.Null(await _service.FindCatalogItemAsync(4));
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        _service.Dispose();
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceSqlTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceSqlTests.cs
@@ -1,0 +1,68 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopModernized.Tests.Common;
+using Xunit;
+
+namespace eShopModernized.Tests.Services;
+
+/// <summary>
+/// Covers <see cref="CatalogService"/> create paths, which depend on the SQL
+/// Server HiLo sequence (<c>SELECT NEXT VALUE FOR catalog_hilo</c>). These tests
+/// require a reachable SQL Server (see <see cref="SqlServerFixture"/>) and skip
+/// automatically when one is not available.
+/// </summary>
+[Collection(SqlServerCollection.Name)]
+public class CatalogServiceSqlTests
+{
+    private readonly SqlServerFixture _fixture;
+
+    public CatalogServiceSqlTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private CatalogService CreateService() =>
+        new(_fixture.CreateContext(), new CatalogItemHiLoGenerator());
+
+    [SkippableFact]
+    public void CreateCatalogItem_AssignsSequenceId_AndPersists()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+
+        var item = new CatalogItem
+        {
+            Name = "Sync Created",
+            PictureFileName = "sync.png",
+            CatalogBrandId = 1,
+            CatalogTypeId = 1,
+            Price = 12m
+        };
+
+        CreateService().CreateCatalogItem(item);
+
+        Assert.True(item.Id > 0);
+        using var context = _fixture.CreateContext();
+        Assert.NotNull(context.CatalogItems.Find(item.Id));
+    }
+
+    [SkippableFact]
+    public async Task CreateCatalogItemAsync_AssignsSequenceId_AndPersists()
+    {
+        Skip.IfNot(_fixture.Available, _fixture.SkipReason);
+
+        var item = new CatalogItem
+        {
+            Name = "Async Created",
+            PictureFileName = "async.png",
+            CatalogBrandId = 2,
+            CatalogTypeId = 2,
+            Price = 24m
+        };
+
+        await CreateService().CreateCatalogItemAsync(item);
+
+        Assert.True(item.Id > 0);
+        using var context = _fixture.CreateContext();
+        Assert.NotNull(await context.CatalogItems.FindAsync(item.Id));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/CatalogServiceTests.cs
@@ -1,0 +1,154 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopModernized.Tests.Common;
+using Xunit;
+
+namespace eShopModernized.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CatalogService"/> read/update/remove paths using the EF
+/// Core in-memory provider. The create paths rely on a SQL Server HiLo sequence
+/// and are covered separately in <see cref="CatalogServiceSqlTests"/>.
+/// </summary>
+public class CatalogServiceTests
+{
+    private static CatalogService CreateService(string dbName) =>
+        new(InMemoryContext.Create(dbName), new CatalogItemHiLoGenerator());
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_ReturnsPage()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        var page = await CreateService(db).GetCatalogItemsPaginatedAsync(pageSize: 2, pageIndex: 0);
+
+        Assert.Equal(3, page.TotalItems);
+        Assert.Equal(2, page.Data.Count());
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsPage()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        var page = CreateService(db).GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+        Assert.Equal(3, page.TotalItems);
+        Assert.Equal(2, page.Data.Count());
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ReturnsItemWithNavigations()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        var item = await CreateService(db).FindCatalogItemAsync(1);
+
+        Assert.NotNull(item);
+        Assert.NotNull(item!.CatalogBrand);
+        Assert.NotNull(item.CatalogType);
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsNull_WhenMissing()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        Assert.Null(CreateService(db).FindCatalogItem(999));
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsAll()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        Assert.Equal(2, (await CreateService(db).GetCatalogTypesAsync()).Count());
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsAll()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        Assert.Equal(2, CreateService(db).GetCatalogTypes().Count());
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsAll()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        Assert.Equal(3, (await CreateService(db).GetCatalogBrandsAsync()).Count());
+    }
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsAll()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        Assert.Equal(3, CreateService(db).GetCatalogBrands().Count());
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_PersistsChanges()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        var edited = new CatalogItem { Id = 1, Name = "Updated Async", PictureFileName = "1.png", CatalogBrandId = 1, CatalogTypeId = 1, Price = 99m };
+        await CreateService(db).UpdateCatalogItemAsync(edited);
+
+        Assert.Equal("Updated Async", CreateService(db).FindCatalogItem(1)!.Name);
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_PersistsChanges()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        var edited = new CatalogItem { Id = 2, Name = "Updated Sync", PictureFileName = "2.png", CatalogBrandId = 2, CatalogTypeId = 2, Price = 5m };
+        CreateService(db).UpdateCatalogItem(edited);
+
+        Assert.Equal("Updated Sync", CreateService(db).FindCatalogItem(2)!.Name);
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_DeletesItem()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        await CreateService(db).RemoveCatalogItemAsync(new CatalogItem { Id = 3 });
+
+        Assert.Null(CreateService(db).FindCatalogItem(3));
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_DeletesItem()
+    {
+        var db = Guid.NewGuid().ToString();
+        InMemoryContext.CreateSeeded(db).Dispose();
+
+        CreateService(db).RemoveCatalogItem(new CatalogItem { Id = 1 });
+
+        Assert.Null(CreateService(db).FindCatalogItem(1));
+    }
+
+    [Fact]
+    public void Dispose_DisposesUnderlyingContext()
+    {
+        var db = Guid.NewGuid().ToString();
+        var service = CreateService(db);
+
+        service.Dispose();
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/ImageAzureStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/ImageAzureStorageTests.cs
@@ -1,0 +1,238 @@
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Services;
+
+public class ImageAzureStorageTests
+{
+    private static readonly Uri AccountUri = new("https://acct.blob.core.windows.net/");
+
+    private readonly Mock<BlobServiceClient> _blobService = new();
+    private readonly Mock<IConfiguration> _configuration = new();
+    private readonly Mock<ICatalogConfiguration> _catalogConfiguration = new();
+    private readonly Mock<ILogger<ImageAzureStorage>> _logger = new();
+
+    public ImageAzureStorageTests()
+    {
+        _blobService.SetupGet(b => b.Uri).Returns(AccountUri);
+    }
+
+    private ImageAzureStorage CreateStorage() =>
+        new(_blobService.Object, _configuration.Object, _catalogConfiguration.Object, _logger.Object);
+
+    private static AsyncPageable<BlobItem> Pageable(params BlobItem[] items)
+    {
+        var page = Page<BlobItem>.FromValues(items, continuationToken: null, Mock.Of<Response>());
+        return AsyncPageable<BlobItem>.FromPages(new[] { page });
+    }
+
+    private static IFormFile FormFile(string name, string contentType = "image/png")
+    {
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns(name);
+        file.SetupGet(f => f.ContentType).Returns(contentType);
+        file.Setup(f => f.OpenReadStream()).Returns(new MemoryStream(new byte[] { 1, 2, 3 }));
+        return file.Object;
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsAccountUri()
+    {
+        Assert.Equal(AccountUri.ToString(), CreateStorage().BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPath()
+    {
+        Assert.Equal($"{AccountUri}pics/temp/default.png", CreateStorage().UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsDefault_WhenNoPicture()
+    {
+        var item = new CatalogItem { Id = 1, PictureFileName = string.Empty };
+
+        Assert.Equal($"{AccountUri}pics/temp/default.png", CreateStorage().BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsItemPath_WhenPicturePresent()
+    {
+        var item = new CatalogItem { Id = 9, PictureFileName = "9.png" };
+
+        Assert.Equal($"{AccountUri}pics/9/9.png", CreateStorage().BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        CreateStorage().Dispose();
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_UploadsAndReturnsUri_WithCatalogItemId()
+    {
+        var blobUri = new Uri($"{AccountUri}pics/5/temp/photo.png");
+        var blobClient = new Mock<BlobClient>();
+        blobClient.SetupGet(b => b.Uri).Returns(blobUri);
+        blobClient.Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContentInfo(default, default, default, default, default), Mock.Of<Response>()));
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContainerInfo(default, default), Mock.Of<Response>()));
+        container.Setup(c => c.GetBlobClient(It.IsAny<string>())).Returns(blobClient.Object);
+
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        var result = await CreateStorage().UploadTempImageAsync(FormFile("Photo.PNG"), 5);
+
+        Assert.Equal(blobUri.ToString(), result);
+        blobClient.Verify(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_UsesGuidPath_WhenNoCatalogItemId()
+    {
+        var blobClient = new Mock<BlobClient>();
+        blobClient.SetupGet(b => b.Uri).Returns(new Uri($"{AccountUri}pics/temp/x/photo.png"));
+        blobClient.Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContentInfo(default, default, default, default, default), Mock.Of<Response>()));
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContainerInfo(default, default), Mock.Of<Response>()));
+        container.Setup(c => c.GetBlobClient(It.IsAny<string>())).Returns(blobClient.Object);
+
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        var result = await CreateStorage().UploadTempImageAsync(FormFile("photo.png"), null);
+
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_LogsAndRethrows_OnError()
+    {
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Throws(new RequestFailedException("boom"));
+
+        await Assert.ThrowsAsync<RequestFailedException>(() => CreateStorage().UploadTempImageAsync(FormFile("photo.png"), 1));
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_ReturnsEarly_WhenNoTempImage()
+    {
+        var container = new Mock<BlobContainerClient>();
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        await CreateStorage().UpdateImageAsync(new CatalogItem { Id = 1, TempImageName = null });
+
+        container.Verify(c => c.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CopiesTempToFinal_AndCleansUp()
+    {
+        var tempBlob = new Mock<BlobClient>();
+        tempBlob.SetupGet(b => b.Uri).Returns(new Uri($"{AccountUri}pics/1/temp/new.png"));
+        tempBlob.Setup(b => b.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+
+        var oldBlob = new Mock<BlobClient>();
+        oldBlob.Setup(b => b.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+
+        var copyOperation = new Mock<CopyFromUriOperation>();
+        copyOperation.Setup(o => o.WaitForCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<Response<long>>(Response.FromValue(1L, Mock.Of<Response>())));
+
+        var imageBlob = new Mock<BlobClient>();
+        imageBlob.Setup(b => b.StartCopyFromUriAsync(It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(),
+                It.IsAny<AccessTier?>(), It.IsAny<BlobRequestConditions>(), It.IsAny<BlobRequestConditions>(),
+                It.IsAny<RehydratePriority?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(copyOperation.Object);
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.GetBlobClient("1/temp/new.png")).Returns(tempBlob.Object);
+        container.Setup(c => c.GetBlobClient("old/old.png")).Returns(oldBlob.Object);
+        container.Setup(c => c.GetBlobClient("1/new.png")).Returns(imageBlob.Object);
+        container.Setup(c => c.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), "1/", It.IsAny<CancellationToken>()))
+            .Returns(Pageable(BlobsModelFactory.BlobItem(name: "old/old.png")));
+
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        await CreateStorage().UpdateImageAsync(new CatalogItem { Id = 1, TempImageName = "/pics/1/temp/new.png" });
+
+        imageBlob.Verify(b => b.StartCopyFromUriAsync(It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(),
+            It.IsAny<AccessTier?>(), It.IsAny<BlobRequestConditions>(), It.IsAny<BlobRequestConditions>(),
+            It.IsAny<RehydratePriority?>(), It.IsAny<CancellationToken>()), Times.Once);
+        tempBlob.Verify(b => b.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_LogsAndRethrows_OnError()
+    {
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Throws(new RequestFailedException("boom"));
+
+        await Assert.ThrowsAsync<RequestFailedException>(() =>
+            CreateStorage().UpdateImageAsync(new CatalogItem { Id = 1, TempImageName = "/pics/1/temp/x.png" }));
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CreatesContainer_ClearsAndSeedsImages()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var picsDir = Path.Combine(currentDir, "wwwroot", "Pics");
+        Directory.CreateDirectory(picsDir);
+        await File.WriteAllBytesAsync(Path.Combine(picsDir, "1.png"), new byte[] { 1 });
+        await File.WriteAllBytesAsync(Path.Combine(picsDir, "default.png"), new byte[] { 2 });
+
+        var uploadBlob = new Mock<BlobClient>();
+        uploadBlob.Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContentInfo(default, default, default, default, default), Mock.Of<Response>()));
+
+        var existingBlob = new Mock<BlobClient>();
+        existingBlob.Setup(b => b.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(true, Mock.Of<Response>()));
+
+        var container = new Mock<BlobContainerClient>();
+        container.Setup(c => c.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Response.FromValue(BlobsModelFactory.BlobContainerInfo(default, default), Mock.Of<Response>()));
+        container.Setup(c => c.GetBlobsAsync(It.IsAny<BlobTraits>(), It.IsAny<BlobStates>(), null, It.IsAny<CancellationToken>()))
+            .Returns(Pageable(BlobsModelFactory.BlobItem(name: "stale.png")));
+        container.Setup(c => c.GetBlobClient("stale.png")).Returns(existingBlob.Object);
+        container.Setup(c => c.GetBlobClient(It.Is<string>(s => s != "stale.png"))).Returns(uploadBlob.Object);
+
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Returns(container.Object);
+
+        try
+        {
+            await CreateStorage().InitializeCatalogImagesAsync();
+        }
+        finally
+        {
+            try { File.Delete(Path.Combine(picsDir, "1.png")); } catch { }
+            try { File.Delete(Path.Combine(picsDir, "default.png")); } catch { }
+        }
+
+        existingBlob.Verify(b => b.DeleteIfExistsAsync(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+        uploadBlob.Verify(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_LogsAndRethrows_OnError()
+    {
+        _blobService.Setup(b => b.GetBlobContainerClient("pics")).Throws(new RequestFailedException("boom"));
+
+        await Assert.ThrowsAsync<RequestFailedException>(() => CreateStorage().InitializeCatalogImagesAsync());
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/Services/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/Services/ImageMockStorageTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace eShopModernized.Tests.Services;
+
+public class ImageMockStorageTests
+{
+    private readonly Mock<IWebHostEnvironment> _environment = new();
+    private readonly Mock<ILogger<ImageMockStorage>> _logger = new();
+
+    private ImageMockStorage CreateStorage() => new(_environment.Object, _logger.Object);
+
+    [Fact]
+    public void BaseUrl_ReturnsPicsPath()
+    {
+        Assert.Equal("/pics/", CreateStorage().BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPath()
+    {
+        Assert.Equal("/pics/default.png", CreateStorage().UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsDefault_WhenNoPicture()
+    {
+        var item = new CatalogItem { Id = 1, PictureFileName = string.Empty };
+
+        Assert.Equal("/pics/default.png", CreateStorage().BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void BuildUrlImage_ReturnsItemPath_WhenPicturePresent()
+    {
+        var item = new CatalogItem { Id = 7, PictureFileName = "7.png" };
+
+        Assert.Equal("/pics/7/7.png", CreateStorage().BuildUrlImage(item));
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CompletesSuccessfully()
+    {
+        await CreateStorage().InitializeCatalogImagesAsync();
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CompletesSuccessfully()
+    {
+        await CreateStorage().UpdateImageAsync(new CatalogItem { Id = 1 });
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_ReturnsMockUrl()
+    {
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns("photo.png");
+        file.Setup(f => f.OpenReadStream()).Returns(new MemoryStream(Encoding.UTF8.GetBytes("x")));
+
+        var url = await CreateStorage().UploadTempImageAsync(file.Object, 3);
+
+        Assert.Equal("/pics/temp/photo.png", url);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        CreateStorage().Dispose();
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ViewModel/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ViewModel/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,41 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.ViewModel;
+using Xunit;
+
+namespace eShopModernized.Tests.ViewModel;
+
+public class PaginatedItemsViewModelTests
+{
+    [Fact]
+    public void Constructor_SetsProperties_AndComputesTotalPages()
+    {
+        var data = new List<CatalogItem> { new() { Id = 1 }, new() { Id = 2 } };
+
+        var model = new PaginatedItemsViewModel<CatalogItem>(pageIndex: 1, pageSize: 10, count: 25, data: data);
+
+        Assert.Equal(1, model.ActualPage);
+        Assert.Equal(10, model.ItemsPerPage);
+        Assert.Equal(25, model.TotalItems);
+        Assert.Equal(3, model.TotalPages);
+        Assert.Same(data, model.Data);
+    }
+
+    [Fact]
+    public void Constructor_ComputesExactTotalPages_WhenEvenlyDivisible()
+    {
+        var model = new PaginatedItemsViewModel<CatalogItem>(0, 5, 20, new List<CatalogItem>());
+
+        Assert.Equal(4, model.TotalPages);
+    }
+
+    [Fact]
+    public void TotalPages_IsSettable()
+    {
+        var model = new PaginatedItemsViewModel<CatalogItem>(0, 5, 20, new List<CatalogItem>())
+        {
+            TotalPages = 99
+        };
+
+        Assert.Equal(99, model.TotalPages);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/eShopCoreModernized/eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a new test project `eShopModernized/tests/eShopModernized.Tests` (xUnit + Moq + EF Core in-memory) covering the `eShopCoreModernized` app. **121 tests, all passing; 83.4% line coverage overall and ≥80% for every testable class.** No production code was changed.

Per-class line coverage (from `reportgenerator`):

| Class | % | | Class | % |
| --- | --- | --- | --- | --- |
| `CatalogConfiguration` | 100 | | `CatalogService` | 100 |
| `AccountController` | 100 | | `CatalogServiceMock` | 100 |
| `BrandsController` | 100 | | `ImageMockStorage` | 100 |
| `CatalogController` | 100 | | `ImageAzureStorage` | 96 |
| `FilesController` | 100 | | `CatalogItemHiLoGenerator` | 100 |
| `HealthController` | 100 | | `CatalogBrand/Item/Type` | 100 |
| `ImageUploadController` | 100 | | `PaginatedItemsViewModel<T>` | 100 |
| `PicController` | 82 | | `MigrationTelemetryInitializer` | 100 |
| `AppSettingsSqlConnectionFactory` | 100 | | `ManagedIdentitySqlConnectionFactory` | 77 (see note) |

### How the tricky dependencies are handled

- **Controllers** — mocked `ICatalogService`/`IImageService`/`ICatalogConfiguration`/`ILogger<T>`; a shared `MvcTestContext` wires up `ControllerContext`, `RequestServices` (incl. `IUrlHelperFactory` so `RedirectToAction` works), `ViewData`/`TempData`.
- **`HealthController` / `CatalogService`** — real `CatalogDBContext` via the EF Core **in-memory** provider; the DB-unhealthy path is exercised by disposing the context.
- **`ImageAzureStorage`** — fully mocked `BlobServiceClient`/`BlobContainerClient`/`BlobClient` (including `StartCopyFromUriAsync` → `CopyFromUriOperation`) so upload/update/initialize happy-paths and error paths run without Azure.
- **HiLo sequence** (`CatalogItemHiLoGenerator`, `CatalogService.CreateCatalogItem[Async]`) — needs real SQL Server (`SELECT NEXT VALUE FOR catalog_hilo`). `SqlServerFixture` provisions a throw-away DB. Because the model's `HasAnnotation("DatabaseGenerated", None)` doesn't actually disable identity, the fixture builds the schema from `GenerateCreateScript()` with `IDENTITY` stripped so explicit HiLo ids insert cleanly. These tests use `Xunit.SkippableFact` and **skip automatically when no server is reachable**, so `dotnet test` stays green everywhere.

### Documented coverage gap

- **`ManagedIdentitySqlConnectionFactory` (77%)** — the final lines assign a successfully-acquired AAD token to the connection; reaching them needs a live managed-identity environment. The test covers everything up to the token request and asserts the credential-unavailable path. Documented in the test README.
- `Program` and the generated `Views_*` Razor classes are not unit-testable and are intentionally excluded.

## How to run

```bash
cd eShopModernized/tests/eShopModernized.Tests
dotnet test                                   # all tests (SQL tests skip if no server)
dotnet test --collect:"XPlat Code Coverage"   # + coverage
```

See `eShopModernized/tests/eShopModernized.Tests/README.md` for the coverage-report steps and SQL Server setup.


Link to Devin session: https://app.devin.ai/sessions/3a20a682904a4d5fadf8cf941e57cd91
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/46?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->