### PR TITLE
Add search and filter bar to catalog list page

### DIFF
--- a/eShopModernizedMVCSolution/src/eShopModernizedMVC/Controllers/CatalogController.cs
+++ b/eShopModernizedMVCSolution/src/eShopModernizedMVC/Controllers/CatalogController.cs
@@ -22,11 +22,18 @@ namespace eShopModernizedMVC.Controllers
         }
 
         // GET /[?pageSize=3&pageIndex=10]
-        public ActionResult Index(int pageSize = 10, int pageIndex = 0)
+        public ActionResult Index(int pageSize = 10, int pageIndex = 0, string searchText = null, int? brandId = null, int? typeId = null)
         {
-            _log.Info($"Now loading... /Catalog/Index?pageSize={pageSize}&pageIndex={pageIndex}");
-            var paginatedItems = _service.GetCatalogItemsPaginated(pageSize, pageIndex);
+            _log.Info($"Now loading... /Catalog/Index?pageSize={pageSize}&pageIndex={pageIndex}&searchText={searchText}&brandId={brandId}&typeId={typeId}");
+            var paginatedItems = _service.GetCatalogItemsPaginated(pageSize, pageIndex, searchText, brandId, typeId);
             ChangeUriPlaceholder(paginatedItems.Data);
+
+            ViewBag.CatalogBrandId = new SelectList(_service.GetCatalogBrands(), "Id", "Brand", brandId);
+            ViewBag.CatalogTypeId = new SelectList(_service.GetCatalogTypes(), "Id", "Type", typeId);
+            ViewBag.SearchText = searchText;
+            ViewBag.BrandId = brandId;
+            ViewBag.TypeId = typeId;
+
             return View(paginatedItems);
         }
 

--- a/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/CatalogService.cs
+++ b/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/CatalogService.cs
@@ -19,11 +19,34 @@ namespace eShopModernizedMVC.Services
 
         public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex)
         {
-            var totalItems = db.CatalogItems.LongCount();
+            return GetCatalogItemsPaginated(pageSize, pageIndex, null, null, null);
+        }
 
-            var itemsOnPage = db.CatalogItems
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, string searchText, int? brandId, int? typeId)
+        {
+            var query = db.CatalogItems
                 .Include(c => c.CatalogBrand)
                 .Include(c => c.CatalogType)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(searchText))
+            {
+                query = query.Where(c => c.Name.Contains(searchText) || c.Description.Contains(searchText));
+            }
+
+            if (brandId.HasValue)
+            {
+                query = query.Where(c => c.CatalogBrandId == brandId.Value);
+            }
+
+            if (typeId.HasValue)
+            {
+                query = query.Where(c => c.CatalogTypeId == typeId.Value);
+            }
+
+            var totalItems = query.LongCount();
+
+            var itemsOnPage = query
                 .OrderBy(c => c.Id)
                 .Skip(pageSize * pageIndex)
                 .Take(pageSize)

--- a/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/CatalogServiceMock.cs
+++ b/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/CatalogServiceMock.cs
@@ -29,6 +29,38 @@ namespace eShopModernizedMVC.Services
                 pageIndex, pageSize, items.Count, itemsOnPage);
         }
 
+        public PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, string searchText, int? brandId, int? typeId)
+        {
+            var items = ComposeCatalogItems(catalogItems).AsEnumerable();
+
+            if (!string.IsNullOrWhiteSpace(searchText))
+            {
+                items = items.Where(c => (c.Name != null && c.Name.Contains(searchText))
+                    || (c.Description != null && c.Description.Contains(searchText)));
+            }
+
+            if (brandId.HasValue)
+            {
+                items = items.Where(c => c.CatalogBrandId == brandId.Value);
+            }
+
+            if (typeId.HasValue)
+            {
+                items = items.Where(c => c.CatalogTypeId == typeId.Value);
+            }
+
+            var filteredItems = items.ToList();
+
+            var itemsOnPage = filteredItems
+                .OrderBy(c => c.Id)
+                .Skip(pageSize * pageIndex)
+                .Take(pageSize)
+                .ToList();
+
+            return new PaginatedItemsViewModel<CatalogItem>(
+                pageIndex, pageSize, filteredItems.Count, itemsOnPage);
+        }
+
         public CatalogItem FindCatalogItem(int id)
         {
             return catalogItems.FirstOrDefault(x => x.Id == id);

--- a/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/ICatalogService.cs
+++ b/eShopModernizedMVCSolution/src/eShopModernizedMVC/Services/ICatalogService.cs
@@ -10,6 +10,7 @@ namespace eShopModernizedMVC.Services
         CatalogItem FindCatalogItem(int id);
         IEnumerable<CatalogBrand> GetCatalogBrands();
         PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex);
+        PaginatedItemsViewModel<CatalogItem> GetCatalogItemsPaginated(int pageSize, int pageIndex, string searchText, int? brandId, int? typeId);
         IEnumerable<CatalogType> GetCatalogTypes();
         void CreateCatalogItem(CatalogItem catalogItem);
         void UpdateCatalogItem(CatalogItem catalogItem);

--- a/eShopModernizedMVCSolution/src/eShopModernizedMVC/Views/Catalog/Index.cshtml
+++ b/eShopModernizedMVCSolution/src/eShopModernizedMVC/Views/Catalog/Index.cshtml
@@ -9,6 +9,20 @@
         @Html.ActionLink("Create New", "Create", null, new { @class = "btn esh-button esh-button-primary" })
     </p>
 
+    @using (Html.BeginForm("Index", "Catalog", FormMethod.Get, new { @class = "esh-search form-inline" }))
+    {
+        <div class="form-group">
+            @Html.TextBox("searchText", (string)ViewBag.SearchText, new { @class = "form-control", @placeholder = "Search name or description" })
+        </div>
+        <div class="form-group">
+            @Html.DropDownList("brandId", (SelectList)ViewBag.CatalogBrandId, "All brands", new { @class = "form-control" })
+        </div>
+        <div class="form-group">
+            @Html.DropDownList("typeId", (SelectList)ViewBag.CatalogTypeId, "All types", new { @class = "form-control" })
+        </div>
+        <input type="submit" value="[ Search ]" class="btn esh-button esh-button-primary" />
+    }
+
     @Html.Partial("CatalogTable", Model.Data)
 
     <div class="esh-pager">
@@ -18,11 +32,11 @@
 
                     @if (Model.ActualPage > 0)
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, searchText = (string)ViewBag.SearchText, brandId = (int?)ViewBag.BrandId, typeId = (int?)ViewBag.TypeId }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Previous", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage - 1, searchText = (string)ViewBag.SearchText, brandId = (int?)ViewBag.BrandId, typeId = (int?)ViewBag.TypeId }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
                     <span class="esh-pager-item">
@@ -31,11 +45,11 @@
 
                     @if (Model.ActualPage < Model.TotalPages - 1)
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, searchText = (string)ViewBag.SearchText, brandId = (int?)ViewBag.BrandId, typeId = (int?)ViewBag.TypeId }, new { @class = "esh-pager-item esh-pager-item--navigable" })
                     }
                     else
                     {
-                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1 }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
+                        @Html.ActionLink("Next", "Index", new { pageSize = Model.ItemsPerPage, pageIndex = Model.ActualPage + 1, searchText = (string)ViewBag.SearchText, brandId = (int?)ViewBag.BrandId, typeId = (int?)ViewBag.TypeId }, new { @class = "esh-pager-item esh-pager-item--navigable esh-pager-item--hidden" })
                     }
 
             </nav>


### PR DESCRIPTION
## Summary
Adds a search-and-filter bar to the MVC catalog list page (`eShopModernizedMVC`) so users can filter products by a free-text search on `Name`/`Description`, by `CatalogBrand`, and by `CatalogType`, while preserving the existing pagination.

The filtering is applied in the service layer as optional predicates, so `totalItems` (and therefore page count) reflects the filtered result set:

```
GetCatalogItemsPaginated(pageSize, pageIndex, searchText, brandId, typeId):
    query = CatalogItems.Include(Brand).Include(Type)
    if searchText:  query = query.Where(Name.Contains(searchText) || Description.Contains(searchText))
    if brandId:     query = query.Where(CatalogBrandId == brandId)
    if typeId:      query = query.Where(CatalogTypeId == typeId)
    totalItems = query.LongCount()          // filtered count -> correct paging
    itemsOnPage = query.OrderBy(Id).Skip(pageSize*pageIndex).Take(pageSize)
```

The existing parameterless-filter overload is kept and now delegates to the new method with null filters, so all current callers keep working.

## Changes
- **`Services/ICatalogService.cs` + `CatalogService.cs`**: new `GetCatalogItemsPaginated(int pageSize, int pageIndex, string searchText, int? brandId, int? typeId)` overload; old overload delegates to it with nulls.
- **`Services/CatalogServiceMock.cs`**: implements the new overload (in-memory LINQ) to satisfy the interface for the mock-data path.
- **`Controllers/CatalogController.cs`**: `Index` now accepts `searchText`, `brandId`, `typeId`; passes them to the service; populates `ViewBag.CatalogBrandId`/`CatalogTypeId` `SelectList`s (like Create/Edit) and stashes current filter values in `ViewBag` for the view.
- **`Views/Catalog/Index.cshtml`**: adds a GET filter form (`Html.BeginForm("Index","Catalog",FormMethod.Get)`) with a search textbox and Brand/Type dropdowns (each with an "All" empty option), styled with existing `esh-*`/Bootstrap classes; Previous/Next pagination `ActionLink`s now carry `searchText`/`brandId`/`typeId` so filters persist across pages.

## Verification
Verified `eShopModernizedMVC.csproj` (net472) compiles and builds to `bin/eShopModernizedMVC.dll` via MSBuild. Build was done on Linux/Mono, which required environment-only workarounds (installing Mono's MSBuild, restoring NuGet packages, and `Disable_CopyWebApplication=true` for a Mono publish-target quirk) — no repo files were changed for these.

Note: the build surfaced a pre-existing inconsistency unrelated to this change — `eShopModernizedMVC.csproj` references `Microsoft.Owin` / `Microsoft.Owin.Security.Cookies` at `4.0.1` while `packages.config` pins `4.2.2`. Left as-is; flagging for awareness.


Link to Devin session: https://app.devin.ai/sessions/c775f8e3cf844d539bd09bf9fb7082a9
Requested by: @giladsamuels-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/53?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->