### PR TITLE
Add xUnit test framework and comprehensive coverage for eShopModernized

### DIFF
--- a/eShopModernized/eShopModernized.sln
+++ b/eShopModernized/eShopModernized.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FC6FB34B-9B24-44F6-B606-650C28C4492F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopModernized", "src\eShopCoreModernized\eShopModernized.csproj", "{0E29BB26-7D94-48FA-9C06-12E8268A9E65}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0B9821FE-0596-4990-83CC-DB63B1F78509}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopModernized.Tests", "tests\eShopModernized.Tests\eShopModernized.Tests.csproj", "{751AC985-14D0-4F95-AC96-F5BBD3D41312}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0E29BB26-7D94-48FA-9C06-12E8268A9E65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E29BB26-7D94-48FA-9C06-12E8268A9E65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E29BB26-7D94-48FA-9C06-12E8268A9E65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E29BB26-7D94-48FA-9C06-12E8268A9E65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{751AC985-14D0-4F95-AC96-F5BBD3D41312}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{751AC985-14D0-4F95-AC96-F5BBD3D41312}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{751AC985-14D0-4F95-AC96-F5BBD3D41312}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{751AC985-14D0-4F95-AC96-F5BBD3D41312}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0E29BB26-7D94-48FA-9C06-12E8268A9E65} = {FC6FB34B-9B24-44F6-B606-650C28C4492F}
+		{751AC985-14D0-4F95-AC96-F5BBD3D41312} = {0B9821FE-0596-4990-83CC-DB63B1F78509}
+	EndGlobalSection
+EndGlobal

--- a/eShopModernized/tests/README.md
+++ b/eShopModernized/tests/README.md
@@ -1,0 +1,24 @@
+# eShopModernized Tests
+
+xUnit test suite for the .NET 8 `eShopCoreModernized` application.
+
+## Running the tests
+
+From the `eShopModernized/` directory (requires the .NET 8 SDK):
+
+```bash
+dotnet test
+```
+
+Or target the test project directly:
+
+```bash
+dotnet test tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+```
+
+## Layout
+
+- `eShopModernized.Tests/` — xUnit test project referencing
+  `src/eShopCoreModernized`.
+- `CatalogServiceMockTests.cs` — tests for the in-memory `CatalogServiceMock`,
+  which needs no database and serves as an example for adding more tests.

--- a/eShopModernized/tests/eShopModernized.Tests/AccountControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/AccountControllerTests.cs
@@ -1,0 +1,126 @@
+using System.Security.Claims;
+using eShopCoreModernized.Controllers;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class AccountControllerTests
+{
+    private readonly Mock<IAuthenticationService> _authService = new();
+
+    private AccountController CreateController(bool treatReturnUrlAsLocal = true)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_authService.Object);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        var controller = new AccountController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+            TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>()),
+        };
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(u => u.IsLocalUrl(It.IsAny<string>())).Returns(treatReturnUrlAsLocal);
+        controller.Url = urlHelper.Object;
+
+        return controller;
+    }
+
+    [Fact]
+    public void Login_Get_ReturnsViewWithReturnUrlInViewData()
+    {
+        var controller = CreateController();
+
+        var result = controller.Login("/protected");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("/protected", controller.ViewData["ReturnUrl"]);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithValidCredentials_SignsInAndRedirectsToCatalog()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Login("alice", "secret");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+        _authService.Verify(a => a.SignInAsync(
+            It.IsAny<HttpContext>(),
+            "Cookies",
+            It.Is<ClaimsPrincipal>(p => p.HasClaim(ClaimTypes.Name, "alice")),
+            It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithLocalReturnUrl_RedirectsToReturnUrl()
+    {
+        var controller = CreateController(treatReturnUrlAsLocal: true);
+
+        var result = await controller.Login("alice", "secret", "/dashboard");
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/dashboard", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithNonLocalReturnUrl_RedirectsToCatalog()
+    {
+        var controller = CreateController(treatReturnUrlAsLocal: false);
+
+        var result = await controller.Login("alice", "secret", "http://evil.example.com");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+    }
+
+    [Theory]
+    [InlineData("", "secret")]
+    [InlineData("alice", "")]
+    [InlineData("", "")]
+    public async Task Login_Post_WithMissingCredentials_ReturnsViewWithError(string username, string password)
+    {
+        var controller = CreateController();
+
+        var result = await controller.Login(username, password, "/back");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("Invalid username or password", controller.ViewData["Error"]);
+        Assert.Equal("/back", controller.ViewData["ReturnUrl"]);
+        _authService.Verify(a => a.SignInAsync(
+            It.IsAny<HttpContext>(), It.IsAny<string>(),
+            It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Logout_SignsOutAndRedirectsToCatalog()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Logout();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+        _authService.Verify(a => a.SignOutAsync(
+            It.IsAny<HttpContext>(), "Cookies", It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public void AccessDenied_ReturnsView()
+    {
+        var result = CreateController().AccessDenied();
+
+        Assert.IsType<ViewResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/BrandsControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/BrandsControllerTests.cs
@@ -1,0 +1,77 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class BrandsControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+
+    private BrandsController CreateController() =>
+        new(_service.Object, NullLogger<BrandsController>.Instance);
+
+    private static List<CatalogBrand> SampleBrands() => new()
+    {
+        new CatalogBrand { Id = 1, Brand = "Azure" },
+        new CatalogBrand { Id = 2, Brand = "Visual Studio" },
+    };
+
+    [Fact]
+    public async Task Get_ReturnsOkWithAllBrands()
+    {
+        var brands = SampleBrands();
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(brands);
+
+        var result = await CreateController().Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Same(brands, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetById_WithExistingId_ReturnsOkWithBrand()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Get(2);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var brand = Assert.IsType<CatalogBrand>(ok.Value);
+        Assert.Equal(2, brand.Id);
+        Assert.Equal("Visual Studio", brand.Brand);
+    }
+
+    [Fact]
+    public async Task GetById_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Get(999);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Delete_WithExistingId_ReturnsOk()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Delete(1);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Delete(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogBrandTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogBrandTests.cs
@@ -1,0 +1,24 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogBrandTests
+{
+    [Fact]
+    public void Constructor_InitializesBrandToEmptyString()
+    {
+        var brand = new CatalogBrand();
+
+        Assert.Equal(0, brand.Id);
+        Assert.Equal(string.Empty, brand.Brand);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var brand = new CatalogBrand { Id = 5, Brand = "Azure" };
+
+        Assert.Equal(5, brand.Id);
+        Assert.Equal("Azure", brand.Brand);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogConfigurationTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogConfigurationTests.cs
@@ -1,0 +1,96 @@
+using eShopCoreModernized.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace eShopModernized.Tests;
+
+public class CatalogConfigurationTests
+{
+    private static ICatalogConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        return new CatalogConfiguration(configuration);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("True", true)]
+    [InlineData("False", false)]
+    public void UseMockData_ReflectsConfiguredBooleanValue(string configured, bool expected)
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AppSettings:UseMockData"] = configured
+        });
+
+        Assert.Equal(expected, config.UseMockData);
+    }
+
+    [Fact]
+    public void BooleanProperties_MapToExpectedConfigurationKeys()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AppSettings:UseMockData"] = "true",
+            ["AppSettings:UseAzureStorage"] = "true",
+            ["AppSettings:UseAzureManagedIdentity"] = "true",
+            ["AppSettings:UseCustomizationData"] = "true",
+            ["AppSettings:UseAzureActiveDirectory"] = "true"
+        });
+
+        Assert.True(config.UseMockData);
+        Assert.True(config.UseAzureStorage);
+        Assert.True(config.UseManagedIdentity);
+        Assert.True(config.UseCustomizationData);
+        Assert.True(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void BooleanProperties_DefaultToFalse_WhenKeysMissing()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>());
+
+        Assert.False(config.UseMockData);
+        Assert.False(config.UseAzureStorage);
+        Assert.False(config.UseManagedIdentity);
+        Assert.False(config.UseCustomizationData);
+        Assert.False(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void StringProperties_ReturnConfiguredValues()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Azure:StorageConnectionString"] = "storage-cs",
+            ["Azure:ApplicationInsights:InstrumentationKey"] = "ikey",
+            ["Azure:ApplicationInsights:ConnectionString"] = "ai-cs",
+            ["Azure:ActiveDirectory:ClientId"] = "client-id",
+            ["Azure:ActiveDirectory:TenantId"] = "tenant-id",
+            ["Azure:ActiveDirectory:PostLogoutRedirectUri"] = "https://example.com/logout"
+        });
+
+        Assert.Equal("storage-cs", config.StorageConnectionString);
+        Assert.Equal("ikey", config.AppInsightsInstrumentationKey);
+        Assert.Equal("ai-cs", config.AppInsightsConnectionString);
+        Assert.Equal("client-id", config.AzureActiveDirectoryClientId);
+        Assert.Equal("tenant-id", config.AzureActiveDirectoryTenant);
+        Assert.Equal("https://example.com/logout", config.PostLogoutRedirectUri);
+    }
+
+    [Fact]
+    public void StringProperties_FallBackToEmptyString_WhenKeysMissing()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>());
+
+        Assert.Equal(string.Empty, config.StorageConnectionString);
+        Assert.Equal(string.Empty, config.AppInsightsInstrumentationKey);
+        Assert.Equal(string.Empty, config.AppInsightsConnectionString);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryClientId);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryTenant);
+        Assert.Equal(string.Empty, config.PostLogoutRedirectUri);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogControllerTests.cs
@@ -1,0 +1,269 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.ViewModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class CatalogControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<IImageService> _imageService = new();
+    private readonly Mock<ICatalogConfiguration> _config = new();
+
+    private CatalogController CreateController() =>
+        new(_service.Object, _imageService.Object, _config.Object, NullLogger<CatalogController>.Instance);
+
+    private static CatalogItem NewItem(int id, string name = "Item") =>
+        new() { Id = id, Name = name, PictureFileName = "pic.png" };
+
+    [Fact]
+    public async Task Index_ReturnsViewWithPaginatedItems_AndBuildsImageUris()
+    {
+        var items = new[] { NewItem(1), NewItem(2) };
+        var paginated = new PaginatedItemsViewModel<CatalogItem>(0, 10, 2, items);
+        _service.Setup(s => s.GetCatalogItemsPaginatedAsync(10, 0)).ReturnsAsync(paginated);
+        _imageService.Setup(i => i.BuildUrlImage(It.IsAny<CatalogItem>())).Returns("http://img/x.png");
+        var controller = CreateController();
+
+        var result = await controller.Index();
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(paginated, view.Model);
+        _imageService.Verify(i => i.BuildUrlImage(It.IsAny<CatalogItem>()), Times.Exactly(2));
+        Assert.All(items, i => Assert.Equal("http://img/x.png", i.PictureUri));
+    }
+
+    [Fact]
+    public async Task Details_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Details(null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Details_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(99)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Details(99);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Details_WithValidId_ReturnsViewWithItemAndImageUri()
+    {
+        var item = NewItem(3);
+        _service.Setup(s => s.FindCatalogItemAsync(3)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/3.png");
+
+        var result = await CreateController().Details(3);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        Assert.Equal("http://img/3.png", item.PictureUri);
+    }
+
+    [Fact]
+    public async Task Create_Get_ReturnsViewWithDefaultImageAndPopulatesViewBag()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        _imageService.Setup(i => i.UrlDefaultImage()).Returns("default.png");
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+        var controller = CreateController();
+
+        var result = await controller.Create();
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<CatalogItem>(view.Model);
+        Assert.Equal("default.png", model.PictureUri);
+        Assert.Equal(true, controller.ViewBag.UseAzureStorage);
+        Assert.NotNull(controller.ViewBag.CatalogBrandId);
+        Assert.NotNull(controller.ViewBag.CatalogTypeId);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithValidModel_CreatesItemAndRedirectsToIndex()
+    {
+        var item = NewItem(0, "New");
+        var controller = CreateController();
+
+        var result = await controller.Create(item);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithTempImage_UpdatesImageAndSetsPictureFileName()
+    {
+        var item = NewItem(0, "New");
+        item.TempImageName = "/tmp/uploaded.png";
+        var controller = CreateController();
+
+        var result = await controller.Create(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("uploaded.png", item.PictureFileName);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithInvalidModel_ReturnsViewWithItem()
+    {
+        var item = NewItem(0, "New");
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+
+        var result = await controller.Create(item);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.CreateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Edit((int?)null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(42)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Edit(42);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithValidId_ReturnsViewWithItem()
+    {
+        var item = NewItem(5);
+        _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/5.png");
+
+        var result = await CreateController().Edit(5);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task EditPost_WithValidModel_UpdatesItemAndRedirectsToIndex()
+    {
+        var item = NewItem(6, "Edited");
+        var controller = CreateController();
+
+        var result = await controller.Edit(item);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EditPost_WithTempImage_UpdatesImageAndSetsPictureFileName()
+    {
+        var item = NewItem(7, "Edited");
+        item.TempImageName = "/tmp/new.png";
+        var controller = CreateController();
+
+        var result = await controller.Edit(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("new.png", item.PictureFileName);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task EditPost_WithInvalidModel_ReturnsViewWithoutUpdating()
+    {
+        var item = NewItem(8, "Edited");
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+
+        var result = await controller.Edit(item);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.UpdateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Delete((int?)null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(11)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Delete(11);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithValidId_ReturnsViewWithItem()
+    {
+        var item = NewItem(12);
+        _service.Setup(s => s.FindCatalogItemAsync(12)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/12.png");
+
+        var result = await CreateController().Delete(12);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithExistingItem_RemovesAndRedirectsToIndex()
+    {
+        var item = NewItem(13);
+        _service.Setup(s => s.FindCatalogItemAsync(13)).ReturnsAsync(item);
+
+        var result = await CreateController().DeleteConfirmed(13);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.RemoveCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithMissingItem_RedirectsWithoutRemoving()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(14)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().DeleteConfirmed(14);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _service.Verify(s => s.RemoveCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogDBContextTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogDBContextTests.cs
@@ -1,0 +1,105 @@
+using eShopCoreModernized.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests;
+
+public class CatalogDBContextTests
+{
+    private static CatalogDBContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new CatalogDBContext(options);
+    }
+
+    [Fact]
+    public void DbSets_AreInitialized()
+    {
+        using var context = CreateInMemoryContext();
+
+        Assert.NotNull(context.CatalogItems);
+        Assert.NotNull(context.CatalogBrands);
+        Assert.NotNull(context.CatalogTypes);
+    }
+
+    [Fact]
+    public void AddAndQuery_CatalogItem_PersistsAndRetrievesEntity()
+    {
+        using var context = CreateInMemoryContext();
+
+        context.CatalogItems.Add(new CatalogItem
+        {
+            Id = 1,
+            Name = "Mug",
+            Price = 12M,
+            CatalogBrandId = 1,
+            CatalogTypeId = 1,
+        });
+        context.SaveChanges();
+
+        var stored = context.CatalogItems.Single();
+        Assert.Equal("Mug", stored.Name);
+        Assert.Equal(12M, stored.Price);
+    }
+
+    [Fact]
+    public void AddAndQuery_CatalogBrandAndType_PersistEntities()
+    {
+        using var context = CreateInMemoryContext();
+
+        context.CatalogBrands.Add(new CatalogBrand { Id = 1, Brand = "Contoso" });
+        context.CatalogTypes.Add(new CatalogType { Id = 1, Type = "Mug" });
+        context.SaveChanges();
+
+        Assert.Equal("Contoso", context.CatalogBrands.Single().Brand);
+        Assert.Equal("Mug", context.CatalogTypes.Single().Type);
+    }
+
+    [Fact]
+    public void Model_ConfiguresExpectedTableNames()
+    {
+        using var context = CreateInMemoryContext();
+
+        Assert.Equal("Catalog", context.Model.FindEntityType(typeof(CatalogItem))!.GetTableName());
+        Assert.Equal("CatalogBrand", context.Model.FindEntityType(typeof(CatalogBrand))!.GetTableName());
+        Assert.Equal("CatalogType", context.Model.FindEntityType(typeof(CatalogType))!.GetTableName());
+    }
+
+    [Fact]
+    public void Model_ConfiguresPrimaryKeys()
+    {
+        using var context = CreateInMemoryContext();
+
+        var itemKey = context.Model.FindEntityType(typeof(CatalogItem))!.FindPrimaryKey();
+        Assert.NotNull(itemKey);
+        Assert.Equal(nameof(CatalogItem.Id), Assert.Single(itemKey!.Properties).Name);
+    }
+
+    [Fact]
+    public void Model_ConfiguresRequiredForeignKeysOnCatalogItem()
+    {
+        using var context = CreateInMemoryContext();
+        var itemType = context.Model.FindEntityType(typeof(CatalogItem))!;
+
+        var brandFk = itemType.GetForeignKeys()
+            .Single(fk => fk.PrincipalEntityType.ClrType == typeof(CatalogBrand));
+        var typeFk = itemType.GetForeignKeys()
+            .Single(fk => fk.PrincipalEntityType.ClrType == typeof(CatalogType));
+
+        Assert.True(brandFk.IsRequired);
+        Assert.Equal(nameof(CatalogItem.CatalogBrandId), Assert.Single(brandFk.Properties).Name);
+        Assert.True(typeFk.IsRequired);
+        Assert.Equal(nameof(CatalogItem.CatalogTypeId), Assert.Single(typeFk.Properties).Name);
+    }
+
+    [Fact]
+    public void Model_IgnoresPictureUriProperty()
+    {
+        using var context = CreateInMemoryContext();
+        var itemType = context.Model.FindEntityType(typeof(CatalogItem))!;
+
+        Assert.Null(itemType.FindProperty(nameof(CatalogItem.PictureUri)));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogItemHiLoGeneratorTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogItemHiLoGeneratorTests.cs
@@ -1,0 +1,117 @@
+using System.Reflection;
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+/// <summary>
+/// Tests for <see cref="CatalogItemHiLoGenerator"/>.
+///
+/// The generator's "cold" path (when its lo-id block is exhausted) issues a raw
+/// <c>SELECT NEXT VALUE FOR catalog_hilo</c> against the DB connection, which
+/// requires a real SQL Server and cannot be exercised with the EF Core in-memory
+/// provider. The unit-testable behavior is the in-memory bookkeeping: once a
+/// block has been reserved, the generator hands out <c>HiLoIncrement</c>
+/// consecutive ids without touching the database.
+///
+/// To reach that "warm" path deterministically without a database, these tests
+/// pre-seed the generator's private <c>sequenceId</c>/<c>remainningLoIds</c>
+/// fields via reflection. In the warm path the <c>db</c> argument is never
+/// dereferenced, so a null context is passed to prove no DB access occurs.
+/// </summary>
+public class CatalogItemHiLoGeneratorTests
+{
+    private const int HiLoIncrement = 10;
+
+    private static void Prime(CatalogItemHiLoGenerator gen, int sequenceId, int remainingLoIds)
+    {
+        SetField(gen, "sequenceId", sequenceId);
+        SetField(gen, "remainningLoIds", remainingLoIds);
+    }
+
+    private static void SetField(object target, string name, object value)
+    {
+        var field = typeof(CatalogItemHiLoGenerator)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static int GetField(object target, string name)
+    {
+        var field = typeof(CatalogItemHiLoGenerator)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        return (int)field!.GetValue(target)!;
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_WarmBlock_IncrementsWithoutDatabaseAccess()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 100, remainingLoIds: 5);
+
+        // db is null: the warm path must not touch it.
+        var value = gen.GetNextSequenceValue(db: null!);
+
+        Assert.Equal(101, value);
+        Assert.Equal(4, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_WarmBlock_HandsOutConsecutiveIds()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 200, remainingLoIds: HiLoIncrement - 1);
+
+        var issued = new List<int>();
+        for (int i = 0; i < HiLoIncrement - 1; i++)
+        {
+            issued.Add(gen.GetNextSequenceValue(db: null!));
+        }
+
+        Assert.Equal(Enumerable.Range(201, HiLoIncrement - 1), issued);
+        Assert.Equal(0, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public async Task GetNextSequenceValueAsync_WarmBlock_ReturnsNextId()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 50, remainingLoIds: 3);
+
+        var value = await gen.GetNextSequenceValueAsync(db: null!);
+
+        Assert.Equal(51, value);
+        Assert.Equal(2, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_ExhaustedWarmBlock_FallsBackToDatabase()
+    {
+        // With no remaining lo-ids the generator must consult the DB for a fresh
+        // block. Passing a null context proves it takes the cold path (rather
+        // than silently reusing stale bookkeeping) by throwing on DB access.
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 100, remainingLoIds: 0);
+
+        Assert.ThrowsAny<Exception>(() => gen.GetNextSequenceValue(db: null!));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_ConcurrentWarmCalls_ProduceUniqueContiguousIds()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        const int callCount = 500;
+        Prime(gen, sequenceId: 1000, remainingLoIds: callCount);
+
+        var results = new int[callCount];
+        Parallel.For(0, callCount, i =>
+        {
+            results[i] = gen.GetNextSequenceValue(db: null!);
+        });
+
+        var distinct = results.Distinct().ToList();
+        Assert.Equal(callCount, distinct.Count);
+        Assert.Equal(Enumerable.Range(1001, callCount), distinct.OrderBy(x => x));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogItemTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogItemTests.cs
@@ -1,0 +1,83 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogItemTests
+{
+    [Fact]
+    public void Constructor_DefaultsPictureFileNameToDefaultPictureName()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(CatalogItem.DefaultPictureName, item.PictureFileName);
+        Assert.Equal("dummy.png", CatalogItem.DefaultPictureName);
+    }
+
+    [Fact]
+    public void Constructor_InitializesNameToEmptyStringAndReferencesToNull()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(string.Empty, item.Name);
+        Assert.Null(item.Description);
+        Assert.Null(item.PictureUri);
+        Assert.Null(item.TempImageName);
+        Assert.Null(item.CatalogBrand);
+        Assert.Null(item.CatalogType);
+        Assert.False(item.OnReorder);
+    }
+
+    [Fact]
+    public void NavigationProperties_CanBeAssignedAndLinkToForeignKeys()
+    {
+        var brand = new CatalogBrand { Id = 3, Brand = "Contoso" };
+        var type = new CatalogType { Id = 7, Type = "Mug" };
+
+        var item = new CatalogItem
+        {
+            Id = 1,
+            Name = "Mug",
+            Price = 9.99M,
+            CatalogBrandId = brand.Id,
+            CatalogBrand = brand,
+            CatalogTypeId = type.Id,
+            CatalogType = type,
+        };
+
+        Assert.Same(brand, item.CatalogBrand);
+        Assert.Equal(item.CatalogBrandId, item.CatalogBrand!.Id);
+        Assert.Same(type, item.CatalogType);
+        Assert.Equal(item.CatalogTypeId, item.CatalogType!.Id);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var item = new CatalogItem
+        {
+            Id = 42,
+            Name = "Widget",
+            Description = "A useful widget",
+            Price = 123.45M,
+            PictureFileName = "widget.png",
+            PictureUri = "http://example/widget.png",
+            TempImageName = "temp.png",
+            AvailableStock = 10,
+            RestockThreshold = 2,
+            MaxStockThreshold = 20,
+            OnReorder = true,
+        };
+
+        Assert.Equal(42, item.Id);
+        Assert.Equal("Widget", item.Name);
+        Assert.Equal("A useful widget", item.Description);
+        Assert.Equal(123.45M, item.Price);
+        Assert.Equal("widget.png", item.PictureFileName);
+        Assert.Equal("http://example/widget.png", item.PictureUri);
+        Assert.Equal("temp.png", item.TempImageName);
+        Assert.Equal(10, item.AvailableStock);
+        Assert.Equal(2, item.RestockThreshold);
+        Assert.Equal(20, item.MaxStockThreshold);
+        Assert.True(item.OnReorder);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogServiceMockTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogServiceMockTests.cs
@@ -1,0 +1,57 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+
+namespace eShopModernized.Tests;
+
+public class CatalogServiceMockTests
+{
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsRequestedPage()
+    {
+        var service = new CatalogServiceMock();
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+        Assert.Equal(5, result.TotalItems);
+        Assert.Equal(2, result.Data.Count());
+        Assert.Equal(0, result.ActualPage);
+        Assert.Equal(2, result.ItemsPerPage);
+        Assert.Equal(3, result.TotalPages);
+    }
+
+    [Fact]
+    public void FindCatalogItem_ReturnsMatchingItem()
+    {
+        var service = new CatalogServiceMock();
+
+        var item = service.FindCatalogItem(2);
+
+        Assert.NotNull(item);
+        Assert.Equal(2, item!.Id);
+        Assert.Equal(".NET Black & White Mug", item.Name);
+    }
+
+    [Fact]
+    public void CreateCatalogItem_AssignsNewIdAndAddsItem()
+    {
+        var service = new CatalogServiceMock();
+        var newItem = new CatalogItem { Name = "Test Item", Description = "Test", Price = 1M };
+
+        service.CreateCatalogItem(newItem);
+
+        Assert.Equal(6, newItem.Id);
+        Assert.NotNull(service.FindCatalogItem(6));
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_DeletesItem()
+    {
+        var service = new CatalogServiceMock();
+        var item = service.FindCatalogItem(1);
+        Assert.NotNull(item);
+
+        service.RemoveCatalogItem(item!);
+
+        Assert.Null(service.FindCatalogItem(1));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogServiceTests.cs
@@ -1,0 +1,336 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests;
+
+/// <summary>
+/// Tests for the EF Core-backed <see cref="CatalogService"/> using the
+/// in-memory provider. Each test spins up an isolated in-memory database
+/// (unique name) and, where persistence matters, uses a fresh
+/// <see cref="CatalogDBContext"/> per logical operation so results reflect
+/// what was actually written to the store rather than the change tracker.
+///
+/// Note: create paths (<see cref="CatalogService.CreateCatalogItem"/> and its
+/// async twin) rely on <see cref="CatalogItemHiLoGenerator"/>, which issues a
+/// raw <c>SELECT NEXT VALUE FOR catalog_hilo</c> against the DB connection. The
+/// in-memory provider has no relational connection, so those paths cannot be
+/// exercised end-to-end here; they are documented via
+/// <see cref="CreateCatalogItem_WithInMemoryProvider_ThrowsBecauseHiLoNeedsSql"/>.
+/// </summary>
+public class CatalogServiceTests
+{
+    private static DbContextOptions<CatalogDBContext> NewOptions() =>
+        new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+    private static void Seed(DbContextOptions<CatalogDBContext> options)
+    {
+        using var db = new CatalogDBContext(options);
+
+        db.CatalogBrands.AddRange(
+            new CatalogBrand { Id = 1, Brand = "Azure" },
+            new CatalogBrand { Id = 2, Brand = ".NET" });
+
+        db.CatalogTypes.AddRange(
+            new CatalogType { Id = 1, Type = "Mug" },
+            new CatalogType { Id = 2, Type = "T-Shirt" });
+
+        for (int i = 1; i <= 5; i++)
+        {
+            db.CatalogItems.Add(new CatalogItem
+            {
+                Id = i,
+                Name = $"Item {i}",
+                Description = $"Description {i}",
+                Price = i,
+                PictureFileName = $"{i}.png",
+                CatalogBrandId = (i % 2) + 1,
+                CatalogTypeId = (i % 2) + 1,
+                AvailableStock = 100
+            });
+        }
+
+        db.SaveChanges();
+    }
+
+    private static CatalogService NewService(DbContextOptions<CatalogDBContext> options) =>
+        new CatalogService(new CatalogDBContext(options), new CatalogItemHiLoGenerator());
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsRequestedPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+        Assert.Equal(5, result.TotalItems);
+        Assert.Equal(2, result.ItemsPerPage);
+        Assert.Equal(0, result.ActualPage);
+        Assert.Equal(3, result.TotalPages);
+        Assert.Equal(new[] { 1, 2 }, result.Data.Select(i => i.Id));
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsPartialLastPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 2);
+
+        Assert.Single(result.Data);
+        Assert.Equal(5, result.Data.Single().Id);
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_PastLastPage_ReturnsEmptyButKeepsTotals()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 10);
+
+        Assert.Empty(result.Data);
+        Assert.Equal(5, result.TotalItems);
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_IncludesBrandAndTypeNavigations()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 5, pageIndex: 0);
+
+        Assert.All(result.Data, item =>
+        {
+            Assert.NotNull(item.CatalogBrand);
+            Assert.NotNull(item.CatalogType);
+        });
+    }
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_ReturnsRequestedPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = await service.GetCatalogItemsPaginatedAsync(pageSize: 3, pageIndex: 0);
+
+        Assert.Equal(5, result.TotalItems);
+        Assert.Equal(3, result.Data.Count());
+        Assert.Equal(new[] { 1, 2, 3 }, result.Data.Select(i => i.Id));
+    }
+
+    [Fact]
+    public void FindCatalogItem_ExistingId_ReturnsItemWithNavigations()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var item = service.FindCatalogItem(3);
+
+        Assert.NotNull(item);
+        Assert.Equal(3, item!.Id);
+        Assert.Equal("Item 3", item.Name);
+        Assert.NotNull(item.CatalogBrand);
+        Assert.NotNull(item.CatalogType);
+    }
+
+    [Fact]
+    public void FindCatalogItem_UnknownId_ReturnsNull()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        Assert.Null(service.FindCatalogItem(999));
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ExistingId_ReturnsItem()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var item = await service.FindCatalogItemAsync(1);
+
+        Assert.NotNull(item);
+        Assert.Equal(1, item!.Id);
+    }
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsAllSeededBrands()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var brands = service.GetCatalogBrands().ToList();
+
+        Assert.Equal(2, brands.Count);
+        Assert.Contains(brands, b => b.Brand == "Azure");
+        Assert.Contains(brands, b => b.Brand == ".NET");
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsAllSeededBrands()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var brands = await service.GetCatalogBrandsAsync();
+
+        Assert.Equal(2, brands.Count());
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsAllSeededTypes()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var types = service.GetCatalogTypes().ToList();
+
+        Assert.Equal(2, types.Count);
+        Assert.Contains(types, t => t.Type == "Mug");
+        Assert.Contains(types, t => t.Type == "T-Shirt");
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsAllSeededTypes()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var types = await service.GetCatalogTypesAsync();
+
+        Assert.Equal(2, types.Count());
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_PersistsChangedFields()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var edited = new CatalogItem
+            {
+                Id = 2,
+                Name = "Renamed",
+                Description = "Updated description",
+                Price = 42.5M,
+                PictureFileName = "2.png",
+                CatalogBrandId = 1,
+                CatalogTypeId = 1,
+                AvailableStock = 7
+            };
+
+            service.UpdateCatalogItem(edited);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        var stored = verify.CatalogItems.Single(i => i.Id == 2);
+        Assert.Equal("Renamed", stored.Name);
+        Assert.Equal(42.5M, stored.Price);
+        Assert.Equal(7, stored.AvailableStock);
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_PersistsChangedFields()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var edited = new CatalogItem
+            {
+                Id = 4,
+                Name = "Async Renamed",
+                Price = 99M,
+                PictureFileName = "4.png",
+                CatalogBrandId = 1,
+                CatalogTypeId = 1
+            };
+
+            await service.UpdateCatalogItemAsync(edited);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Equal("Async Renamed", verify.CatalogItems.Single(i => i.Id == 4).Name);
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_DeletesItemFromStore()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var toRemove = service.FindCatalogItem(1);
+            Assert.NotNull(toRemove);
+            service.RemoveCatalogItem(toRemove!);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Null(verify.CatalogItems.FirstOrDefault(i => i.Id == 1));
+        Assert.Equal(4, verify.CatalogItems.Count());
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_DeletesItemFromStore()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var toRemove = await service.FindCatalogItemAsync(5);
+            Assert.NotNull(toRemove);
+            await service.RemoveCatalogItemAsync(toRemove!);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Null(verify.CatalogItems.FirstOrDefault(i => i.Id == 5));
+    }
+
+    [Fact]
+    public void CreateCatalogItem_WithInMemoryProvider_ThrowsBecauseHiLoNeedsSql()
+    {
+        // Documents the boundary: CreateCatalogItem delegates id assignment to
+        // CatalogItemHiLoGenerator, which runs a raw SQL sequence query. The
+        // in-memory provider exposes no relational connection, so this path is
+        // not unit-testable end-to-end without a real SQL Server.
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var newItem = new CatalogItem
+        {
+            Name = "New",
+            Price = 1M,
+            PictureFileName = "new.png",
+            CatalogBrandId = 1,
+            CatalogTypeId = 1
+        };
+
+        Assert.ThrowsAny<Exception>(() => service.CreateCatalogItem(newItem));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogTypeTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogTypeTests.cs
@@ -1,0 +1,24 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogTypeTests
+{
+    [Fact]
+    public void Constructor_InitializesTypeToEmptyString()
+    {
+        var type = new CatalogType();
+
+        Assert.Equal(0, type.Id);
+        Assert.Equal(string.Empty, type.Type);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var type = new CatalogType { Id = 9, Type = "T-Shirt" };
+
+        Assert.Equal(9, type.Id);
+        Assert.Equal("T-Shirt", type.Type);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/FilesControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/FilesControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Text.Json;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class FilesControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+
+    private FilesController CreateController() =>
+        new(_service.Object, NullLogger<FilesController>.Instance);
+
+    [Fact]
+    public async Task Get_ReturnsJsonFileWithBrands()
+    {
+        var brands = new List<CatalogBrand>
+        {
+            new() { Id = 1, Brand = "Azure" },
+            new() { Id = 2, Brand = "Visual Studio" },
+        };
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(brands);
+
+        var result = await CreateController().Get();
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("application/json", file.ContentType);
+
+        var json = Encoding.UTF8.GetString(file.FileContents);
+        var deserialized = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(json);
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized!.Count);
+        Assert.Equal("Azure", deserialized[0].Brand);
+        Assert.Equal(2, deserialized[1].Id);
+    }
+
+    [Fact]
+    public async Task Get_WithNoBrands_ReturnsEmptyJsonArrayFile()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+
+        var result = await CreateController().Get();
+
+        var file = Assert.IsType<FileContentResult>(result);
+        var json = Encoding.UTF8.GetString(file.FileContents);
+        var deserialized = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(json);
+        Assert.NotNull(deserialized);
+        Assert.Empty(deserialized!);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/HealthControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/HealthControllerTests.cs
@@ -1,0 +1,87 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class HealthControllerTests : IDisposable
+{
+    private readonly Mock<ICatalogConfiguration> _config = new();
+    private readonly CatalogDBContext _dbContext;
+
+    public HealthControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase("health-" + Guid.NewGuid().ToString("N"))
+            .Options;
+        _dbContext = new CatalogDBContext(options);
+    }
+
+    private HealthController CreateController() =>
+        new(_config.Object, _dbContext, NullLogger<HealthController>.Instance);
+
+    private static T? ReadProp<T>(object? value, string name) =>
+        (T?)value?.GetType().GetProperty(name)?.GetValue(value);
+
+    private static object? ReadService(object? servicesValue, string key)
+    {
+        var services = Assert.IsAssignableFrom<IDictionary<string, object>>(servicesValue);
+        return services.TryGetValue(key, out var entry) ? entry : null;
+    }
+
+    [Fact]
+    public void Get_ReturnsOkWithHealthyStatus()
+    {
+        var result = CreateController().Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Healthy", ReadProp<string>(ok.Value, "status"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReturnsOkWithStatusAndVersion()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Healthy", ReadProp<string>(ok.Value, "status"));
+        Assert.False(string.IsNullOrEmpty(ReadProp<string>(ok.Value, "version")));
+        Assert.NotNull(ReadProp<object>(ok.Value, "services"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_WhenDatabaseReachable_ReportsHealthyDatabase()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var services = ReadProp<object>(ok.Value, "services");
+        var database = ReadService(services, "database");
+        Assert.NotNull(database);
+        Assert.Equal("Healthy", ReadProp<string>(database, "status"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_WhenAzureStorageEnabledWithoutClient_ReportsNotConfigured()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var services = ReadProp<object>(ok.Value, "services");
+        var azure = ReadService(services, "azureStorage");
+        Assert.NotNull(azure);
+        Assert.Equal("NotConfigured", ReadProp<string>(azure, "status"));
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/eShopModernized/tests/eShopModernized.Tests/IImageServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/IImageServiceTests.cs
@@ -1,0 +1,71 @@
+using Azure.Storage.Blobs;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class IImageServiceTests
+{
+    private static ImageMockStorage CreateMockStorage()
+    {
+        return new ImageMockStorage(
+            new Mock<IWebHostEnvironment>().Object,
+            new Mock<ILogger<ImageMockStorage>>().Object);
+    }
+
+    private static ImageAzureStorage CreateAzureStorage()
+    {
+        return new ImageAzureStorage(
+            new BlobServiceClient(new Uri("https://myaccount.blob.core.windows.net/")),
+            new Mock<IConfiguration>().Object,
+            new Mock<ICatalogConfiguration>().Object,
+            new Mock<ILogger<ImageAzureStorage>>().Object);
+    }
+
+    public static IEnumerable<object[]> Implementations()
+    {
+        yield return new object[] { CreateMockStorage() };
+        yield return new object[] { CreateAzureStorage() };
+    }
+
+    [Fact]
+    public void Implementations_AreDisposable()
+    {
+        Assert.IsAssignableFrom<IDisposable>(CreateMockStorage());
+        Assert.IsAssignableFrom<IDisposable>(CreateAzureStorage());
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BuildUrlImage_WithoutPictureFileName_FallsBackToDefaultImage(IImageService service)
+    {
+        var item = new CatalogItem { Id = 1, PictureFileName = string.Empty };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BaseUrl_IsNonEmpty(IImageService service)
+    {
+        Assert.False(string.IsNullOrEmpty(service.BaseUrl()));
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BuildUrlImage_WithPictureFileName_IncludesItemIdAndFileName(IImageService service)
+    {
+        var item = new CatalogItem { Id = 123, PictureFileName = "gadget.png" };
+
+        var url = service.BuildUrlImage(item);
+
+        Assert.Contains("123", url);
+        Assert.Contains("gadget.png", url);
+        Assert.NotEqual(service.UrlDefaultImage(), url);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageAzureStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageAzureStorageTests.cs
@@ -1,0 +1,98 @@
+using Azure.Storage.Blobs;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageAzureStorageTests
+{
+    private static readonly Uri AccountUri = new("https://myaccount.blob.core.windows.net/");
+
+    private static (ImageAzureStorage Service, BlobServiceClient Client) CreateService(Uri? uri = null)
+    {
+        var client = new BlobServiceClient(uri ?? AccountUri);
+        var configuration = new Mock<IConfiguration>();
+        var catalogConfiguration = new Mock<ICatalogConfiguration>();
+        var logger = new Mock<ILogger<ImageAzureStorage>>();
+
+        var service = new ImageAzureStorage(
+            client,
+            configuration.Object,
+            catalogConfiguration.Object,
+            logger.Object);
+
+        return (service, client);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsBlobServiceUri()
+    {
+        var (service, client) = CreateService();
+
+        Assert.Equal(client.Uri.ToString(), service.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_PointsToTempDefaultBlob()
+    {
+        var (service, client) = CreateService();
+
+        Assert.Equal($"{client.Uri}pics/temp/default.png", service.UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_WithPictureFileName_ReturnsItemScopedBlobUrl()
+    {
+        var (service, client) = CreateService();
+        var item = new CatalogItem { Id = 9, PictureFileName = "shirt.png" };
+
+        Assert.Equal($"{client.Uri}pics/9/shirt.png", service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildUrlImage_WithoutPictureFileName_ReturnsDefaultImage(string? pictureFileName)
+    {
+        var (service, _) = CreateService();
+        var item = new CatalogItem { Id = 9, PictureFileName = pictureFileName! };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void Uris_HonorConfiguredBlobEndpoint()
+    {
+        var (service, client) = CreateService(new Uri("https://another.blob.core.windows.net/"));
+
+        Assert.StartsWith(client.Uri.ToString(), service.BaseUrl());
+        Assert.StartsWith(client.Uri.ToString(), service.UrlDefaultImage());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task UpdateImageAsync_WithoutTempImageName_ReturnsWithoutContactingStorage(string? tempImageName)
+    {
+        var (service, _) = CreateService();
+        var item = new CatalogItem { Id = 5, TempImageName = tempImageName };
+
+        var exception = await Record.ExceptionAsync(() => service.UpdateImageAsync(item));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var (service, _) = CreateService();
+
+        var exception = Record.Exception(() => service.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageMockStorageTests.cs
@@ -1,0 +1,105 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageMockStorageTests
+{
+    private static ImageMockStorage CreateService()
+    {
+        var environment = new Mock<IWebHostEnvironment>();
+        var logger = new Mock<ILogger<ImageMockStorage>>();
+        return new ImageMockStorage(environment.Object, logger.Object);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsPicsRoot()
+    {
+        var service = CreateService();
+
+        Assert.Equal("/pics/", service.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPngPath()
+    {
+        var service = CreateService();
+
+        Assert.Equal("/pics/default.png", service.UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_WithPictureFileName_ReturnsItemScopedPath()
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 7, PictureFileName = "photo.png" };
+
+        Assert.Equal("/pics/7/photo.png", service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildUrlImage_WithoutPictureFileName_ReturnsDefaultImage(string? pictureFileName)
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 7, PictureFileName = pictureFileName! };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_ReturnsTempUrlBasedOnFileName()
+    {
+        var service = CreateService();
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns("upload.png");
+
+        var result = await service.UploadTempImageAsync(file.Object, catalogItemId: 42);
+
+        Assert.Equal("/pics/temp/upload.png", result);
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_WithNullCatalogItemId_StillReturnsTempUrl()
+    {
+        var service = CreateService();
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns("no-id.png");
+
+        var result = await service.UploadTempImageAsync(file.Object, catalogItemId: null);
+
+        Assert.Equal("/pics/temp/no-id.png", result);
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CompletesWithoutError()
+    {
+        var service = CreateService();
+
+        await service.InitializeCatalogImagesAsync();
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CompletesWithoutError()
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 3 };
+
+        await service.UpdateImageAsync(item);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var service = CreateService();
+
+        var exception = Record.Exception(() => service.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageUploadControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageUploadControllerTests.cs
@@ -1,0 +1,95 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageUploadControllerTests
+{
+    private readonly Mock<IImageService> _imageService = new();
+
+    private ImageUploadController CreateController() =>
+        new(_imageService.Object, NullLogger<ImageUploadController>.Instance);
+
+    private static IFormFile FakeFile(string fileName, long length)
+    {
+        var mock = new Mock<IFormFile>();
+        mock.SetupGet(f => f.FileName).Returns(fileName);
+        mock.SetupGet(f => f.Length).Returns(length);
+        return mock.Object;
+    }
+
+    private static string? ReadImageUrl(object? value) =>
+        value?.GetType().GetProperty("imageUrl")?.GetValue(value) as string;
+
+    [Fact]
+    public async Task UploadImage_WithValidPng_ReturnsOkWithImageUrl()
+    {
+        _imageService.Setup(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), 5))
+            .ReturnsAsync("http://img/temp.png");
+
+        var result = await CreateController().UploadImage(FakeFile("photo.png", 100), 5);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("http://img/temp.png", ReadImageUrl(ok.Value));
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), 5), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadImage_WithNullFile_ReturnsBadRequest()
+    {
+        var result = await CreateController().UploadImage(null!);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No file uploaded", bad.Value);
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadImage_WithEmptyFile_ReturnsBadRequest()
+    {
+        var result = await CreateController().UploadImage(FakeFile("photo.png", 0));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No file uploaded", bad.Value);
+    }
+
+    [Theory]
+    [InlineData("document.pdf")]
+    [InlineData("archive.zip")]
+    [InlineData("script.exe")]
+    public async Task UploadImage_WithDisallowedExtension_ReturnsBadRequest(string fileName)
+    {
+        var result = await CreateController().UploadImage(FakeFile(fileName, 100));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Invalid file type. Only JPG, PNG, and GIF files are allowed.", bad.Value);
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadImage_WhenServiceThrows_Returns500()
+    {
+        _imageService.Setup(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await CreateController().UploadImage(FakeFile("photo.jpg", 100));
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, status.StatusCode);
+    }
+
+    [Fact]
+    public void GetDefaultImage_ReturnsOkWithDefaultImageUrl()
+    {
+        _imageService.Setup(i => i.UrlDefaultImage()).Returns("http://img/default.png");
+
+        var result = CreateController().GetDefaultImage();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("http://img/default.png", ReadImageUrl(ok.Value));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/MigrationTelemetryInitializerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/MigrationTelemetryInitializerTests.cs
@@ -1,0 +1,46 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace eShopModernized.Tests;
+
+public class MigrationTelemetryInitializerTests
+{
+    [Fact]
+    public void Initialize_SetsExpectedMigrationGlobalProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new TraceTelemetry();
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(".NET Core 6.0", telemetry.Context.GlobalProperties["ApplicationVersion"]);
+        Assert.Equal("StranglerFig-Complete", telemetry.Context.GlobalProperties["MigrationPhase"]);
+        Assert.Equal("Catalog-Core", telemetry.Context.GlobalProperties["ServiceType"]);
+    }
+
+    [Fact]
+    public void Initialize_AddsExactlyTheExpectedProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new RequestTelemetry();
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(3, telemetry.Context.GlobalProperties.Count);
+        Assert.Contains("ApplicationVersion", telemetry.Context.GlobalProperties.Keys);
+        Assert.Contains("MigrationPhase", telemetry.Context.GlobalProperties.Keys);
+        Assert.Contains("ServiceType", telemetry.Context.GlobalProperties.Keys);
+    }
+
+    [Fact]
+    public void Initialize_OverwritesExistingMigrationProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new TraceTelemetry();
+        telemetry.Context.GlobalProperties["ApplicationVersion"] = "stale";
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(".NET Core 6.0", telemetry.Context.GlobalProperties["ApplicationVersion"]);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,50 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.ViewModel;
+
+namespace eShopModernized.Tests;
+
+public class PaginatedItemsViewModelTests
+{
+    [Theory]
+    [InlineData(0, 10, 0, 0)]      // no items -> no pages
+    [InlineData(0, 10, 10, 1)]     // exactly one full page
+    [InlineData(0, 10, 11, 2)]     // one over a full page -> ceiling rounds up
+    [InlineData(0, 10, 5, 1)]      // partial page still counts as a page
+    [InlineData(0, 3, 10, 4)]      // 10/3 = 3.33 -> 4
+    [InlineData(0, 1, 5, 5)]       // page size of one
+    [InlineData(0, 100, 5, 1)]     // page larger than total item count
+    public void Constructor_ComputesTotalPagesUsingCeiling(int pageIndex, int pageSize, long count, int expectedTotalPages)
+    {
+        var vm = new PaginatedItemsViewModel<CatalogItem>(pageIndex, pageSize, count, Enumerable.Empty<CatalogItem>());
+
+        Assert.Equal(expectedTotalPages, vm.TotalPages);
+    }
+
+    [Fact]
+    public void Constructor_PopulatesAllPropertiesFromArguments()
+    {
+        var data = new[]
+        {
+            new CatalogItem { Id = 1, Name = "A" },
+            new CatalogItem { Id = 2, Name = "B" },
+        };
+
+        var vm = new PaginatedItemsViewModel<CatalogItem>(pageIndex: 2, pageSize: 5, count: 42, data: data);
+
+        Assert.Equal(2, vm.ActualPage);
+        Assert.Equal(5, vm.ItemsPerPage);
+        Assert.Equal(42, vm.TotalItems);
+        Assert.Same(data, vm.Data);
+        Assert.Equal(2, vm.Data.Count());
+    }
+
+    [Fact]
+    public void Constructor_PreservesLargeTotalItemsCount()
+    {
+        long largeCount = (long)int.MaxValue + 100;
+
+        var vm = new PaginatedItemsViewModel<CatalogItem>(0, 1000, largeCount, Enumerable.Empty<CatalogItem>());
+
+        Assert.Equal(largeCount, vm.TotalItems);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/PicControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/PicControllerTests.cs
@@ -1,0 +1,104 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class PicControllerTests : IDisposable
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<IWebHostEnvironment> _environment = new();
+    private readonly string _contentRoot;
+
+    public PicControllerTests()
+    {
+        _contentRoot = Path.Combine(Path.GetTempPath(), "pic-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_contentRoot);
+        _environment.SetupGet(e => e.WebRootPath).Returns(_contentRoot);
+        _environment.SetupGet(e => e.ContentRootPath).Returns(_contentRoot);
+    }
+
+    private PicController CreateController() =>
+        new(_service.Object, NullLogger<PicController>.Instance, _environment.Object);
+
+    private string CreatePicFile(string fileName, byte[] content)
+    {
+        var picsDir = Path.Combine(_contentRoot, "Pics");
+        Directory.CreateDirectory(picsDir);
+        var path = Path.Combine(picsDir, fileName);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Index_WithNonPositiveId_ReturnsBadRequest(int id)
+    {
+        var result = await CreateController().Index(id);
+
+        Assert.IsType<BadRequestResult>(result);
+        _service.Verify(s => s.FindCatalogItemAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Index_WithUnknownItem_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(7)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Index(7);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Index_WhenPictureFileMissingOnDisk_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(8))
+            .ReturnsAsync(new CatalogItem { Id = 8, Name = "X", PictureFileName = "missing.png" });
+
+        var result = await CreateController().Index(8);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Index_WithExistingPictureFile_ReturnsFileWithCorrectMimeType()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        CreatePicFile("item9.png", bytes);
+        _service.Setup(s => s.FindCatalogItemAsync(9))
+            .ReturnsAsync(new CatalogItem { Id = 9, Name = "X", PictureFileName = "item9.png" });
+
+        var result = await CreateController().Index(9);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/png", file.ContentType);
+        Assert.Equal(bytes, file.FileContents);
+    }
+
+    [Fact]
+    public async Task Index_WithJpegPictureFile_ReturnsJpegMimeType()
+    {
+        CreatePicFile("item10.jpg", new byte[] { 9 });
+        _service.Setup(s => s.FindCatalogItemAsync(10))
+            .ReturnsAsync(new CatalogItem { Id = 10, Name = "X", PictureFileName = "item10.jpg" });
+
+        var result = await CreateController().Index(10);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/jpeg", file.ContentType);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_contentRoot))
+        {
+            Directory.Delete(_contentRoot, recursive: true);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/SqlConnectionFactoryTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/SqlConnectionFactoryTests.cs
@@ -1,0 +1,74 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace eShopModernized.Tests;
+
+public class SqlConnectionFactoryTests
+{
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_UsesConfiguredConnectionString()
+    {
+        const string connectionString = "Server=(local);Database=CatalogDb;Integrated Security=true;";
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = connectionString
+        });
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var connection = factory.CreateConnection();
+
+        Assert.NotNull(connection);
+        Assert.Equal(connectionString, connection.ConnectionString);
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_ReturnsEmptyConnectionString_WhenNotConfigured()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>());
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var connection = factory.CreateConnection();
+
+        Assert.NotNull(connection);
+        Assert.Equal(string.Empty, connection.ConnectionString);
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_ReturnsNewInstanceEachCall()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = "Server=(local);Database=CatalogDb;"
+        });
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var first = factory.CreateConnection();
+        using var second = factory.CreateConnection();
+
+        Assert.NotSame(first, second);
+    }
+
+    // ManagedIdentitySqlConnectionFactory.CreateConnection() acquires an Azure AD access
+    // token via DefaultAzureCredential, which requires a live Azure identity environment.
+    // We only cover the constructible path here; exercising CreateConnection() would need a
+    // real managed identity / Azure credential and is therefore excluded from hermetic tests.
+    [Fact]
+    public void ManagedIdentityFactory_CanBeConstructed_WithoutAzureEnvironment()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = "Server=tcp:example.database.windows.net;Database=CatalogDb;"
+        });
+
+        var factory = new ManagedIdentitySqlConnectionFactory(configuration);
+
+        Assert.IsAssignableFrom<ISqlConnectionFactory>(factory);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\eShopCoreModernized\eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopModernized.Tests/eShopModernized.Tests.csproj
@@ -11,7 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Introduces an xUnit test framework for the .NET 8 `eShopCoreModernized` app (previously untested) and builds broad coverage across every component. Work was parallelized across 5 child sessions (PRs #55–#59), each covering one area, then merged into this branch.

**144 tests, all passing** (`cd eShopModernized && dotnet test`).

Scaffold:
- `eShopModernized/eShopModernized.sln` ties the app + test project together.
- `eShopModernized/tests/eShopModernized.Tests/` — xUnit (`net8.0`) referencing xunit, Moq, EF Core InMemory, and Mvc.Testing.

Coverage by area:
- **Services** — `CatalogServiceMock`, `CatalogService` (EF Core InMemory), `ImageMockStorage`, `ImageAzureStorage` (pure/URL logic).
- **Models** — `CatalogItem`/`CatalogBrand`/`CatalogType`, `CatalogDBContext` (runtime model + CRUD), `CatalogItemHiLoGenerator` (warm-path bookkeeping + thread safety).
- **Controllers** — all 7 controllers, constructed with Moq mocks; asserts `IActionResult` types, view models, and service invocations.
- **ViewModel** — `PaginatedItemsViewModel` `TotalPages` ceiling math via `[Theory]`.
- **Configuration/Infrastructure** — `CatalogConfiguration`, `SqlConnectionFactory`, `MigrationTelemetryInitializer`.

Tests are hermetic and fast (no real SQL Server / Azure): EF Core InMemory for DbContext paths, Moq for interfaces. No `src/` production code was modified; child sessions reported no bugs. Paths requiring live SQL Server (HiLo cold path) or live Azure Blob (Azure image upload/init) are documented as untestable at the unit level without a small `src/` refactor or integration harness.


Link to Devin session: https://app.devin.ai/sessions/74b9009b462544b8aa54c17d8d5b992f
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/54?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->