### PR TITLE
Add tests for configuration and infrastructure classes

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/CatalogConfigurationTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogConfigurationTests.cs
@@ -1,0 +1,96 @@
+using eShopCoreModernized.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace eShopModernized.Tests;
+
+public class CatalogConfigurationTests
+{
+    private static ICatalogConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        return new CatalogConfiguration(configuration);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("True", true)]
+    [InlineData("False", false)]
+    public void UseMockData_ReflectsConfiguredBooleanValue(string configured, bool expected)
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AppSettings:UseMockData"] = configured
+        });
+
+        Assert.Equal(expected, config.UseMockData);
+    }
+
+    [Fact]
+    public void BooleanProperties_MapToExpectedConfigurationKeys()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AppSettings:UseMockData"] = "true",
+            ["AppSettings:UseAzureStorage"] = "true",
+            ["AppSettings:UseAzureManagedIdentity"] = "true",
+            ["AppSettings:UseCustomizationData"] = "true",
+            ["AppSettings:UseAzureActiveDirectory"] = "true"
+        });
+
+        Assert.True(config.UseMockData);
+        Assert.True(config.UseAzureStorage);
+        Assert.True(config.UseManagedIdentity);
+        Assert.True(config.UseCustomizationData);
+        Assert.True(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void BooleanProperties_DefaultToFalse_WhenKeysMissing()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>());
+
+        Assert.False(config.UseMockData);
+        Assert.False(config.UseAzureStorage);
+        Assert.False(config.UseManagedIdentity);
+        Assert.False(config.UseCustomizationData);
+        Assert.False(config.UseAzureActiveDirectory);
+    }
+
+    [Fact]
+    public void StringProperties_ReturnConfiguredValues()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Azure:StorageConnectionString"] = "storage-cs",
+            ["Azure:ApplicationInsights:InstrumentationKey"] = "ikey",
+            ["Azure:ApplicationInsights:ConnectionString"] = "ai-cs",
+            ["Azure:ActiveDirectory:ClientId"] = "client-id",
+            ["Azure:ActiveDirectory:TenantId"] = "tenant-id",
+            ["Azure:ActiveDirectory:PostLogoutRedirectUri"] = "https://example.com/logout"
+        });
+
+        Assert.Equal("storage-cs", config.StorageConnectionString);
+        Assert.Equal("ikey", config.AppInsightsInstrumentationKey);
+        Assert.Equal("ai-cs", config.AppInsightsConnectionString);
+        Assert.Equal("client-id", config.AzureActiveDirectoryClientId);
+        Assert.Equal("tenant-id", config.AzureActiveDirectoryTenant);
+        Assert.Equal("https://example.com/logout", config.PostLogoutRedirectUri);
+    }
+
+    [Fact]
+    public void StringProperties_FallBackToEmptyString_WhenKeysMissing()
+    {
+        var config = BuildConfiguration(new Dictionary<string, string?>());
+
+        Assert.Equal(string.Empty, config.StorageConnectionString);
+        Assert.Equal(string.Empty, config.AppInsightsInstrumentationKey);
+        Assert.Equal(string.Empty, config.AppInsightsConnectionString);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryClientId);
+        Assert.Equal(string.Empty, config.AzureActiveDirectoryTenant);
+        Assert.Equal(string.Empty, config.PostLogoutRedirectUri);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/MigrationTelemetryInitializerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/MigrationTelemetryInitializerTests.cs
@@ -1,0 +1,46 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace eShopModernized.Tests;
+
+public class MigrationTelemetryInitializerTests
+{
+    [Fact]
+    public void Initialize_SetsExpectedMigrationGlobalProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new TraceTelemetry();
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(".NET Core 6.0", telemetry.Context.GlobalProperties["ApplicationVersion"]);
+        Assert.Equal("StranglerFig-Complete", telemetry.Context.GlobalProperties["MigrationPhase"]);
+        Assert.Equal("Catalog-Core", telemetry.Context.GlobalProperties["ServiceType"]);
+    }
+
+    [Fact]
+    public void Initialize_AddsExactlyTheExpectedProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new RequestTelemetry();
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(3, telemetry.Context.GlobalProperties.Count);
+        Assert.Contains("ApplicationVersion", telemetry.Context.GlobalProperties.Keys);
+        Assert.Contains("MigrationPhase", telemetry.Context.GlobalProperties.Keys);
+        Assert.Contains("ServiceType", telemetry.Context.GlobalProperties.Keys);
+    }
+
+    [Fact]
+    public void Initialize_OverwritesExistingMigrationProperties()
+    {
+        var initializer = new MigrationTelemetryInitializer();
+        var telemetry = new TraceTelemetry();
+        telemetry.Context.GlobalProperties["ApplicationVersion"] = "stale";
+
+        initializer.Initialize(telemetry);
+
+        Assert.Equal(".NET Core 6.0", telemetry.Context.GlobalProperties["ApplicationVersion"]);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/SqlConnectionFactoryTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/SqlConnectionFactoryTests.cs
@@ -1,0 +1,74 @@
+using eShopCoreModernized.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace eShopModernized.Tests;
+
+public class SqlConnectionFactoryTests
+{
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_UsesConfiguredConnectionString()
+    {
+        const string connectionString = "Server=(local);Database=CatalogDb;Integrated Security=true;";
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = connectionString
+        });
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var connection = factory.CreateConnection();
+
+        Assert.NotNull(connection);
+        Assert.Equal(connectionString, connection.ConnectionString);
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_ReturnsEmptyConnectionString_WhenNotConfigured()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>());
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var connection = factory.CreateConnection();
+
+        Assert.NotNull(connection);
+        Assert.Equal(string.Empty, connection.ConnectionString);
+    }
+
+    [Fact]
+    public void AppSettingsFactory_CreateConnection_ReturnsNewInstanceEachCall()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = "Server=(local);Database=CatalogDb;"
+        });
+        var factory = new AppSettingsSqlConnectionFactory(configuration);
+
+        using var first = factory.CreateConnection();
+        using var second = factory.CreateConnection();
+
+        Assert.NotSame(first, second);
+    }
+
+    // ManagedIdentitySqlConnectionFactory.CreateConnection() acquires an Azure AD access
+    // token via DefaultAzureCredential, which requires a live Azure identity environment.
+    // We only cover the constructible path here; exercising CreateConnection() would need a
+    // real managed identity / Azure credential and is therefore excluded from hermetic tests.
+    [Fact]
+    public void ManagedIdentityFactory_CanBeConstructed_WithoutAzureEnvironment()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:CatalogDBContext"] = "Server=tcp:example.database.windows.net;Database=CatalogDb;"
+        });
+
+        var factory = new ManagedIdentitySqlConnectionFactory(configuration);
+
+        Assert.IsAssignableFrom<ISqlConnectionFactory>(factory);
+    }
+}


### PR DESCRIPTION
## Summary
Adds hermetic xUnit tests for the config/infrastructure area of `eShopCoreModernized`. Follows the conventions in `CatalogServiceMockTests.cs` (`[Fact]`/`[Theory]`, plain `Assert`, `Method_Scenario_Expectation`). Only new `.cs` files added under `tests/eShopModernized.Tests/`; no shared `.csproj`/`.sln` or `src/` changes. `dotnet test` is fully green (19 passed = 4 existing + 15 new).

Classes covered:
- `Configuration/CatalogConfiguration` (`ICatalogConfiguration`) — `CatalogConfigurationTests.cs`. Builds in-memory `IConfiguration` via `ConfigurationBuilder().AddInMemoryCollection(...)` and asserts: bool props map to the right `AppSettings:*` keys and parse `true/false` (incl. casing) via `GetValue<bool>`; bools default to `false` when keys are absent; string props return configured `Azure:*` values and fall back to `string.Empty` when missing.
- `Infrastructure/SqlConnectionFactory` — `SqlConnectionFactoryTests.cs`. For `AppSettingsSqlConnectionFactory`: `CreateConnection()` uses `ConnectionStrings:CatalogDBContext`, yields empty `ConnectionString` when unset, and returns a fresh `SqlConnection` per call — no real SQL connection is opened. For `ManagedIdentitySqlConnectionFactory`: only the constructible path is covered; `CreateConnection()` acquires an Azure AD token via `DefaultAzureCredential` and requires a live Azure identity environment (documented in a test comment).
- `Infrastructure/MigrationTelemetryInitializer` — `MigrationTelemetryInitializerTests.cs`. Constructs telemetry items (`TraceTelemetry`/`RequestTelemetry`), calls `Initialize`, and asserts the three `Context.GlobalProperties` (`ApplicationVersion=.NET Core 6.0`, `MigrationPhase=StranglerFig-Complete`, `ServiceType=Catalog-Core`), that exactly those three are set, and that existing values are overwritten.

## Bugs found
None. `src/` left untouched.


Link to Devin session: https://app.devin.ai/sessions/19f10c3e47464491a1c5b5f026eafe1b
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/55?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->