### PR TITLE
Add tests for domain models and PaginatedItemsViewModel

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/CatalogBrandTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogBrandTests.cs
@@ -1,0 +1,24 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogBrandTests
+{
+    [Fact]
+    public void Constructor_InitializesBrandToEmptyString()
+    {
+        var brand = new CatalogBrand();
+
+        Assert.Equal(0, brand.Id);
+        Assert.Equal(string.Empty, brand.Brand);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var brand = new CatalogBrand { Id = 5, Brand = "Azure" };
+
+        Assert.Equal(5, brand.Id);
+        Assert.Equal("Azure", brand.Brand);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogDBContextTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogDBContextTests.cs
@@ -1,0 +1,105 @@
+using eShopCoreModernized.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests;
+
+public class CatalogDBContextTests
+{
+    private static CatalogDBContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        return new CatalogDBContext(options);
+    }
+
+    [Fact]
+    public void DbSets_AreInitialized()
+    {
+        using var context = CreateInMemoryContext();
+
+        Assert.NotNull(context.CatalogItems);
+        Assert.NotNull(context.CatalogBrands);
+        Assert.NotNull(context.CatalogTypes);
+    }
+
+    [Fact]
+    public void AddAndQuery_CatalogItem_PersistsAndRetrievesEntity()
+    {
+        using var context = CreateInMemoryContext();
+
+        context.CatalogItems.Add(new CatalogItem
+        {
+            Id = 1,
+            Name = "Mug",
+            Price = 12M,
+            CatalogBrandId = 1,
+            CatalogTypeId = 1,
+        });
+        context.SaveChanges();
+
+        var stored = context.CatalogItems.Single();
+        Assert.Equal("Mug", stored.Name);
+        Assert.Equal(12M, stored.Price);
+    }
+
+    [Fact]
+    public void AddAndQuery_CatalogBrandAndType_PersistEntities()
+    {
+        using var context = CreateInMemoryContext();
+
+        context.CatalogBrands.Add(new CatalogBrand { Id = 1, Brand = "Contoso" });
+        context.CatalogTypes.Add(new CatalogType { Id = 1, Type = "Mug" });
+        context.SaveChanges();
+
+        Assert.Equal("Contoso", context.CatalogBrands.Single().Brand);
+        Assert.Equal("Mug", context.CatalogTypes.Single().Type);
+    }
+
+    [Fact]
+    public void Model_ConfiguresExpectedTableNames()
+    {
+        using var context = CreateInMemoryContext();
+
+        Assert.Equal("Catalog", context.Model.FindEntityType(typeof(CatalogItem))!.GetTableName());
+        Assert.Equal("CatalogBrand", context.Model.FindEntityType(typeof(CatalogBrand))!.GetTableName());
+        Assert.Equal("CatalogType", context.Model.FindEntityType(typeof(CatalogType))!.GetTableName());
+    }
+
+    [Fact]
+    public void Model_ConfiguresPrimaryKeys()
+    {
+        using var context = CreateInMemoryContext();
+
+        var itemKey = context.Model.FindEntityType(typeof(CatalogItem))!.FindPrimaryKey();
+        Assert.NotNull(itemKey);
+        Assert.Equal(nameof(CatalogItem.Id), Assert.Single(itemKey!.Properties).Name);
+    }
+
+    [Fact]
+    public void Model_ConfiguresRequiredForeignKeysOnCatalogItem()
+    {
+        using var context = CreateInMemoryContext();
+        var itemType = context.Model.FindEntityType(typeof(CatalogItem))!;
+
+        var brandFk = itemType.GetForeignKeys()
+            .Single(fk => fk.PrincipalEntityType.ClrType == typeof(CatalogBrand));
+        var typeFk = itemType.GetForeignKeys()
+            .Single(fk => fk.PrincipalEntityType.ClrType == typeof(CatalogType));
+
+        Assert.True(brandFk.IsRequired);
+        Assert.Equal(nameof(CatalogItem.CatalogBrandId), Assert.Single(brandFk.Properties).Name);
+        Assert.True(typeFk.IsRequired);
+        Assert.Equal(nameof(CatalogItem.CatalogTypeId), Assert.Single(typeFk.Properties).Name);
+    }
+
+    [Fact]
+    public void Model_IgnoresPictureUriProperty()
+    {
+        using var context = CreateInMemoryContext();
+        var itemType = context.Model.FindEntityType(typeof(CatalogItem))!;
+
+        Assert.Null(itemType.FindProperty(nameof(CatalogItem.PictureUri)));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogItemTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogItemTests.cs
@@ -1,0 +1,83 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogItemTests
+{
+    [Fact]
+    public void Constructor_DefaultsPictureFileNameToDefaultPictureName()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(CatalogItem.DefaultPictureName, item.PictureFileName);
+        Assert.Equal("dummy.png", CatalogItem.DefaultPictureName);
+    }
+
+    [Fact]
+    public void Constructor_InitializesNameToEmptyStringAndReferencesToNull()
+    {
+        var item = new CatalogItem();
+
+        Assert.Equal(string.Empty, item.Name);
+        Assert.Null(item.Description);
+        Assert.Null(item.PictureUri);
+        Assert.Null(item.TempImageName);
+        Assert.Null(item.CatalogBrand);
+        Assert.Null(item.CatalogType);
+        Assert.False(item.OnReorder);
+    }
+
+    [Fact]
+    public void NavigationProperties_CanBeAssignedAndLinkToForeignKeys()
+    {
+        var brand = new CatalogBrand { Id = 3, Brand = "Contoso" };
+        var type = new CatalogType { Id = 7, Type = "Mug" };
+
+        var item = new CatalogItem
+        {
+            Id = 1,
+            Name = "Mug",
+            Price = 9.99M,
+            CatalogBrandId = brand.Id,
+            CatalogBrand = brand,
+            CatalogTypeId = type.Id,
+            CatalogType = type,
+        };
+
+        Assert.Same(brand, item.CatalogBrand);
+        Assert.Equal(item.CatalogBrandId, item.CatalogBrand!.Id);
+        Assert.Same(type, item.CatalogType);
+        Assert.Equal(item.CatalogTypeId, item.CatalogType!.Id);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var item = new CatalogItem
+        {
+            Id = 42,
+            Name = "Widget",
+            Description = "A useful widget",
+            Price = 123.45M,
+            PictureFileName = "widget.png",
+            PictureUri = "http://example/widget.png",
+            TempImageName = "temp.png",
+            AvailableStock = 10,
+            RestockThreshold = 2,
+            MaxStockThreshold = 20,
+            OnReorder = true,
+        };
+
+        Assert.Equal(42, item.Id);
+        Assert.Equal("Widget", item.Name);
+        Assert.Equal("A useful widget", item.Description);
+        Assert.Equal(123.45M, item.Price);
+        Assert.Equal("widget.png", item.PictureFileName);
+        Assert.Equal("http://example/widget.png", item.PictureUri);
+        Assert.Equal("temp.png", item.TempImageName);
+        Assert.Equal(10, item.AvailableStock);
+        Assert.Equal(2, item.RestockThreshold);
+        Assert.Equal(20, item.MaxStockThreshold);
+        Assert.True(item.OnReorder);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogTypeTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogTypeTests.cs
@@ -1,0 +1,24 @@
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+public class CatalogTypeTests
+{
+    [Fact]
+    public void Constructor_InitializesTypeToEmptyString()
+    {
+        var type = new CatalogType();
+
+        Assert.Equal(0, type.Id);
+        Assert.Equal(string.Empty, type.Type);
+    }
+
+    [Fact]
+    public void Properties_RoundTripAssignedValues()
+    {
+        var type = new CatalogType { Id = 9, Type = "T-Shirt" };
+
+        Assert.Equal(9, type.Id);
+        Assert.Equal("T-Shirt", type.Type);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/PaginatedItemsViewModelTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/PaginatedItemsViewModelTests.cs
@@ -1,0 +1,50 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.ViewModel;
+
+namespace eShopModernized.Tests;
+
+public class PaginatedItemsViewModelTests
+{
+    [Theory]
+    [InlineData(0, 10, 0, 0)]      // no items -> no pages
+    [InlineData(0, 10, 10, 1)]     // exactly one full page
+    [InlineData(0, 10, 11, 2)]     // one over a full page -> ceiling rounds up
+    [InlineData(0, 10, 5, 1)]      // partial page still counts as a page
+    [InlineData(0, 3, 10, 4)]      // 10/3 = 3.33 -> 4
+    [InlineData(0, 1, 5, 5)]       // page size of one
+    [InlineData(0, 100, 5, 1)]     // page larger than total item count
+    public void Constructor_ComputesTotalPagesUsingCeiling(int pageIndex, int pageSize, long count, int expectedTotalPages)
+    {
+        var vm = new PaginatedItemsViewModel<CatalogItem>(pageIndex, pageSize, count, Enumerable.Empty<CatalogItem>());
+
+        Assert.Equal(expectedTotalPages, vm.TotalPages);
+    }
+
+    [Fact]
+    public void Constructor_PopulatesAllPropertiesFromArguments()
+    {
+        var data = new[]
+        {
+            new CatalogItem { Id = 1, Name = "A" },
+            new CatalogItem { Id = 2, Name = "B" },
+        };
+
+        var vm = new PaginatedItemsViewModel<CatalogItem>(pageIndex: 2, pageSize: 5, count: 42, data: data);
+
+        Assert.Equal(2, vm.ActualPage);
+        Assert.Equal(5, vm.ItemsPerPage);
+        Assert.Equal(42, vm.TotalItems);
+        Assert.Same(data, vm.Data);
+        Assert.Equal(2, vm.Data.Count());
+    }
+
+    [Fact]
+    public void Constructor_PreservesLargeTotalItemsCount()
+    {
+        long largeCount = (long)int.MaxValue + 100;
+
+        var vm = new PaginatedItemsViewModel<CatalogItem>(0, 1000, largeCount, Enumerable.Empty<CatalogItem>());
+
+        Assert.Equal(largeCount, vm.TotalItems);
+    }
+}


### PR DESCRIPTION
## Summary
Adds xUnit tests for the domain models and view model of the .NET 8 `eShopCoreModernized` app. Only new test `.cs` files were added under `eShopModernized/tests/eShopModernized.Tests/`; no shared project files or `src/` were touched. Full suite is green: **28 passed** (24 new + 4 existing).

Classes covered (one test class per source class):

- **`PaginatedItemsViewModel<T>`** — `[Theory]`/`[InlineData]` verifying the `TotalPages = ceil(count/pageSize)` calculation across page sizes/counts (including 0 items, exact multiples, and page-larger-than-count), plus that `ActualPage`, `ItemsPerPage`, `TotalItems`, and `Data` are populated from the constructor args (and `long` count isn't truncated).
- **`CatalogItem`** — constructor default `PictureFileName == DefaultPictureName ("dummy.png")`, `Name` defaults to empty string with nullable references null, navigation properties (`CatalogBrand`/`CatalogType`) link to their FK ids, and a property round-trip.
- **`CatalogBrand`, `CatalogType`** — minimal construction/round-trip tests (pure data holders; `Brand`/`Type` default to empty string).
- **`CatalogDBContext`** — using the EF Core InMemory provider: DbSets are initialized, entities add/query correctly, and `OnModelCreating` config is asserted via the runtime model — table names (`Catalog`/`CatalogBrand`/`CatalogType`), `Id` primary keys, required FKs (`CatalogBrandId`/`CatalogTypeId`), and that `PictureUri` is ignored (not mapped).

## Notes
- No bugs found in `src/`; production code left untouched.
- No new NuGet packages needed — everything (xunit, Moq, EF Core InMemory) was already referenced by the test project.
- Tests are hermetic/fast: InMemory provider with a fresh unique database per test; no SQL Server or Azure.


Link to Devin session: https://app.devin.ai/sessions/3a2c52c102ba4d18965faeef1f1a6de3
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/56?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->