### PR TITLE
Add tests for image storage services

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/IImageServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/IImageServiceTests.cs
@@ -1,0 +1,71 @@
+using Azure.Storage.Blobs;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class IImageServiceTests
+{
+    private static ImageMockStorage CreateMockStorage()
+    {
+        return new ImageMockStorage(
+            new Mock<IWebHostEnvironment>().Object,
+            new Mock<ILogger<ImageMockStorage>>().Object);
+    }
+
+    private static ImageAzureStorage CreateAzureStorage()
+    {
+        return new ImageAzureStorage(
+            new BlobServiceClient(new Uri("https://myaccount.blob.core.windows.net/")),
+            new Mock<IConfiguration>().Object,
+            new Mock<ICatalogConfiguration>().Object,
+            new Mock<ILogger<ImageAzureStorage>>().Object);
+    }
+
+    public static IEnumerable<object[]> Implementations()
+    {
+        yield return new object[] { CreateMockStorage() };
+        yield return new object[] { CreateAzureStorage() };
+    }
+
+    [Fact]
+    public void Implementations_AreDisposable()
+    {
+        Assert.IsAssignableFrom<IDisposable>(CreateMockStorage());
+        Assert.IsAssignableFrom<IDisposable>(CreateAzureStorage());
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BuildUrlImage_WithoutPictureFileName_FallsBackToDefaultImage(IImageService service)
+    {
+        var item = new CatalogItem { Id = 1, PictureFileName = string.Empty };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BaseUrl_IsNonEmpty(IImageService service)
+    {
+        Assert.False(string.IsNullOrEmpty(service.BaseUrl()));
+    }
+
+    [Theory]
+    [MemberData(nameof(Implementations))]
+    public void BuildUrlImage_WithPictureFileName_IncludesItemIdAndFileName(IImageService service)
+    {
+        var item = new CatalogItem { Id = 123, PictureFileName = "gadget.png" };
+
+        var url = service.BuildUrlImage(item);
+
+        Assert.Contains("123", url);
+        Assert.Contains("gadget.png", url);
+        Assert.NotEqual(service.UrlDefaultImage(), url);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageAzureStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageAzureStorageTests.cs
@@ -1,0 +1,98 @@
+using Azure.Storage.Blobs;
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageAzureStorageTests
+{
+    private static readonly Uri AccountUri = new("https://myaccount.blob.core.windows.net/");
+
+    private static (ImageAzureStorage Service, BlobServiceClient Client) CreateService(Uri? uri = null)
+    {
+        var client = new BlobServiceClient(uri ?? AccountUri);
+        var configuration = new Mock<IConfiguration>();
+        var catalogConfiguration = new Mock<ICatalogConfiguration>();
+        var logger = new Mock<ILogger<ImageAzureStorage>>();
+
+        var service = new ImageAzureStorage(
+            client,
+            configuration.Object,
+            catalogConfiguration.Object,
+            logger.Object);
+
+        return (service, client);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsBlobServiceUri()
+    {
+        var (service, client) = CreateService();
+
+        Assert.Equal(client.Uri.ToString(), service.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_PointsToTempDefaultBlob()
+    {
+        var (service, client) = CreateService();
+
+        Assert.Equal($"{client.Uri}pics/temp/default.png", service.UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_WithPictureFileName_ReturnsItemScopedBlobUrl()
+    {
+        var (service, client) = CreateService();
+        var item = new CatalogItem { Id = 9, PictureFileName = "shirt.png" };
+
+        Assert.Equal($"{client.Uri}pics/9/shirt.png", service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildUrlImage_WithoutPictureFileName_ReturnsDefaultImage(string? pictureFileName)
+    {
+        var (service, _) = CreateService();
+        var item = new CatalogItem { Id = 9, PictureFileName = pictureFileName! };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public void Uris_HonorConfiguredBlobEndpoint()
+    {
+        var (service, client) = CreateService(new Uri("https://another.blob.core.windows.net/"));
+
+        Assert.StartsWith(client.Uri.ToString(), service.BaseUrl());
+        Assert.StartsWith(client.Uri.ToString(), service.UrlDefaultImage());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task UpdateImageAsync_WithoutTempImageName_ReturnsWithoutContactingStorage(string? tempImageName)
+    {
+        var (service, _) = CreateService();
+        var item = new CatalogItem { Id = 5, TempImageName = tempImageName };
+
+        var exception = await Record.ExceptionAsync(() => service.UpdateImageAsync(item));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var (service, _) = CreateService();
+
+        var exception = Record.Exception(() => service.Dispose());
+
+        Assert.Null(exception);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageMockStorageTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageMockStorageTests.cs
@@ -1,0 +1,105 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageMockStorageTests
+{
+    private static ImageMockStorage CreateService()
+    {
+        var environment = new Mock<IWebHostEnvironment>();
+        var logger = new Mock<ILogger<ImageMockStorage>>();
+        return new ImageMockStorage(environment.Object, logger.Object);
+    }
+
+    [Fact]
+    public void BaseUrl_ReturnsPicsRoot()
+    {
+        var service = CreateService();
+
+        Assert.Equal("/pics/", service.BaseUrl());
+    }
+
+    [Fact]
+    public void UrlDefaultImage_ReturnsDefaultPngPath()
+    {
+        var service = CreateService();
+
+        Assert.Equal("/pics/default.png", service.UrlDefaultImage());
+    }
+
+    [Fact]
+    public void BuildUrlImage_WithPictureFileName_ReturnsItemScopedPath()
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 7, PictureFileName = "photo.png" };
+
+        Assert.Equal("/pics/7/photo.png", service.BuildUrlImage(item));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildUrlImage_WithoutPictureFileName_ReturnsDefaultImage(string? pictureFileName)
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 7, PictureFileName = pictureFileName! };
+
+        Assert.Equal(service.UrlDefaultImage(), service.BuildUrlImage(item));
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_ReturnsTempUrlBasedOnFileName()
+    {
+        var service = CreateService();
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns("upload.png");
+
+        var result = await service.UploadTempImageAsync(file.Object, catalogItemId: 42);
+
+        Assert.Equal("/pics/temp/upload.png", result);
+    }
+
+    [Fact]
+    public async Task UploadTempImageAsync_WithNullCatalogItemId_StillReturnsTempUrl()
+    {
+        var service = CreateService();
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.FileName).Returns("no-id.png");
+
+        var result = await service.UploadTempImageAsync(file.Object, catalogItemId: null);
+
+        Assert.Equal("/pics/temp/no-id.png", result);
+    }
+
+    [Fact]
+    public async Task InitializeCatalogImagesAsync_CompletesWithoutError()
+    {
+        var service = CreateService();
+
+        await service.InitializeCatalogImagesAsync();
+    }
+
+    [Fact]
+    public async Task UpdateImageAsync_CompletesWithoutError()
+    {
+        var service = CreateService();
+        var item = new CatalogItem { Id = 3 };
+
+        await service.UpdateImageAsync(item);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var service = CreateService();
+
+        var exception = Record.Exception(() => service.Dispose());
+
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Summary
Adds behavior-focused xUnit tests for the image storage services in `eShopModernized/src/eShopCoreModernized/Services/`. Only new test files were added under `eShopModernized/tests/eShopModernized.Tests/`; no shared `.csproj`/`.sln`, the existing `CatalogServiceMockTests.cs`, or production `src/` code was touched. `dotnet test` is fully green (30 passed, 0 failed).

### Classes covered
- **`ImageMockStorage`** (`ImageMockStorageTests.cs`) — `BaseUrl`, `UrlDefaultImage`, `BuildUrlImage` (item-scoped path vs. default-image fallback when `PictureFileName` is empty/null), `UploadTempImageAsync` (with and without a `catalogItemId`), and the no-op `InitializeCatalogImagesAsync`/`UpdateImageAsync`/`Dispose`. `IFormFile` is mocked with Moq; `IWebHostEnvironment`/`ILogger` are mocked.
- **`ImageAzureStorage`** (`ImageAzureStorageTests.cs`) — the pure/URL-building logic reachable without a live Azure connection: `BaseUrl`, `UrlDefaultImage`, `BuildUrlImage` (item-scoped blob URL vs. default fallback), URL honoring of the configured blob endpoint, `UpdateImageAsync` early-return when `TempImageName` is empty/null (verified to complete without contacting storage), and `Dispose`. Constructed with a real `BlobServiceClient` built from a fake account `Uri` (no network) plus mocked `IConfiguration`/`ICatalogConfiguration`/`ILogger`. Expected URLs are derived from the client's own `Uri` to stay robust.
- **`IImageService`** (`IImageServiceTests.cs`) — polymorphic contract tests run against both implementations via `[MemberData]`: both are `IDisposable`, `BaseUrl` is non-empty, and `BuildUrlImage` falls back to `UrlDefaultImage()` when `PictureFileName` is empty while including the item id + filename otherwise.

### Hard-to-test paths (not covered — require a live Azure Blob endpoint)
`ImageAzureStorage` network-bound branches were intentionally left uncovered because the class takes a concrete `BlobServiceClient` and calls into it directly (no seam to inject mock container/blob clients without editing `src/`):
- `InitializeCatalogImagesAsync` (creates container, enumerates/deletes blobs, uploads seed images from `wwwroot/Pics`).
- `UploadTempImageAsync` (creates container, uploads the stream).
- `UpdateImageAsync` beyond the early return (blob copy/delete).

Covering these would require either integration tests against Azurite or a small refactor of `ImageAzureStorage` to depend on an injectable `BlobContainerClient` factory. No such refactor was made per the instruction to leave `src/` untouched.

### Bugs found
None.


Link to Devin session: https://app.devin.ai/sessions/97f0ccc4d6814efcb70681f3a5acbbec
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/57?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->