### PR TITLE
Add tests for CatalogService and CatalogItemHiLoGenerator

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/CatalogItemHiLoGeneratorTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogItemHiLoGeneratorTests.cs
@@ -1,0 +1,117 @@
+using System.Reflection;
+using eShopCoreModernized.Models;
+
+namespace eShopModernized.Tests;
+
+/// <summary>
+/// Tests for <see cref="CatalogItemHiLoGenerator"/>.
+///
+/// The generator's "cold" path (when its lo-id block is exhausted) issues a raw
+/// <c>SELECT NEXT VALUE FOR catalog_hilo</c> against the DB connection, which
+/// requires a real SQL Server and cannot be exercised with the EF Core in-memory
+/// provider. The unit-testable behavior is the in-memory bookkeeping: once a
+/// block has been reserved, the generator hands out <c>HiLoIncrement</c>
+/// consecutive ids without touching the database.
+///
+/// To reach that "warm" path deterministically without a database, these tests
+/// pre-seed the generator's private <c>sequenceId</c>/<c>remainningLoIds</c>
+/// fields via reflection. In the warm path the <c>db</c> argument is never
+/// dereferenced, so a null context is passed to prove no DB access occurs.
+/// </summary>
+public class CatalogItemHiLoGeneratorTests
+{
+    private const int HiLoIncrement = 10;
+
+    private static void Prime(CatalogItemHiLoGenerator gen, int sequenceId, int remainingLoIds)
+    {
+        SetField(gen, "sequenceId", sequenceId);
+        SetField(gen, "remainningLoIds", remainingLoIds);
+    }
+
+    private static void SetField(object target, string name, object value)
+    {
+        var field = typeof(CatalogItemHiLoGenerator)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    private static int GetField(object target, string name)
+    {
+        var field = typeof(CatalogItemHiLoGenerator)
+            .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        return (int)field!.GetValue(target)!;
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_WarmBlock_IncrementsWithoutDatabaseAccess()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 100, remainingLoIds: 5);
+
+        // db is null: the warm path must not touch it.
+        var value = gen.GetNextSequenceValue(db: null!);
+
+        Assert.Equal(101, value);
+        Assert.Equal(4, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_WarmBlock_HandsOutConsecutiveIds()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 200, remainingLoIds: HiLoIncrement - 1);
+
+        var issued = new List<int>();
+        for (int i = 0; i < HiLoIncrement - 1; i++)
+        {
+            issued.Add(gen.GetNextSequenceValue(db: null!));
+        }
+
+        Assert.Equal(Enumerable.Range(201, HiLoIncrement - 1), issued);
+        Assert.Equal(0, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public async Task GetNextSequenceValueAsync_WarmBlock_ReturnsNextId()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 50, remainingLoIds: 3);
+
+        var value = await gen.GetNextSequenceValueAsync(db: null!);
+
+        Assert.Equal(51, value);
+        Assert.Equal(2, GetField(gen, "remainningLoIds"));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_ExhaustedWarmBlock_FallsBackToDatabase()
+    {
+        // With no remaining lo-ids the generator must consult the DB for a fresh
+        // block. Passing a null context proves it takes the cold path (rather
+        // than silently reusing stale bookkeeping) by throwing on DB access.
+        var gen = new CatalogItemHiLoGenerator();
+        Prime(gen, sequenceId: 100, remainingLoIds: 0);
+
+        Assert.ThrowsAny<Exception>(() => gen.GetNextSequenceValue(db: null!));
+    }
+
+    [Fact]
+    public void GetNextSequenceValue_ConcurrentWarmCalls_ProduceUniqueContiguousIds()
+    {
+        var gen = new CatalogItemHiLoGenerator();
+        const int callCount = 500;
+        Prime(gen, sequenceId: 1000, remainingLoIds: callCount);
+
+        var results = new int[callCount];
+        Parallel.For(0, callCount, i =>
+        {
+            results[i] = gen.GetNextSequenceValue(db: null!);
+        });
+
+        var distinct = results.Distinct().ToList();
+        Assert.Equal(callCount, distinct.Count);
+        Assert.Equal(Enumerable.Range(1001, callCount), distinct.OrderBy(x => x));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogServiceTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogServiceTests.cs
@@ -1,0 +1,336 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopModernized.Tests;
+
+/// <summary>
+/// Tests for the EF Core-backed <see cref="CatalogService"/> using the
+/// in-memory provider. Each test spins up an isolated in-memory database
+/// (unique name) and, where persistence matters, uses a fresh
+/// <see cref="CatalogDBContext"/> per logical operation so results reflect
+/// what was actually written to the store rather than the change tracker.
+///
+/// Note: create paths (<see cref="CatalogService.CreateCatalogItem"/> and its
+/// async twin) rely on <see cref="CatalogItemHiLoGenerator"/>, which issues a
+/// raw <c>SELECT NEXT VALUE FOR catalog_hilo</c> against the DB connection. The
+/// in-memory provider has no relational connection, so those paths cannot be
+/// exercised end-to-end here; they are documented via
+/// <see cref="CreateCatalogItem_WithInMemoryProvider_ThrowsBecauseHiLoNeedsSql"/>.
+/// </summary>
+public class CatalogServiceTests
+{
+    private static DbContextOptions<CatalogDBContext> NewOptions() =>
+        new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+    private static void Seed(DbContextOptions<CatalogDBContext> options)
+    {
+        using var db = new CatalogDBContext(options);
+
+        db.CatalogBrands.AddRange(
+            new CatalogBrand { Id = 1, Brand = "Azure" },
+            new CatalogBrand { Id = 2, Brand = ".NET" });
+
+        db.CatalogTypes.AddRange(
+            new CatalogType { Id = 1, Type = "Mug" },
+            new CatalogType { Id = 2, Type = "T-Shirt" });
+
+        for (int i = 1; i <= 5; i++)
+        {
+            db.CatalogItems.Add(new CatalogItem
+            {
+                Id = i,
+                Name = $"Item {i}",
+                Description = $"Description {i}",
+                Price = i,
+                PictureFileName = $"{i}.png",
+                CatalogBrandId = (i % 2) + 1,
+                CatalogTypeId = (i % 2) + 1,
+                AvailableStock = 100
+            });
+        }
+
+        db.SaveChanges();
+    }
+
+    private static CatalogService NewService(DbContextOptions<CatalogDBContext> options) =>
+        new CatalogService(new CatalogDBContext(options), new CatalogItemHiLoGenerator());
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsRequestedPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 0);
+
+        Assert.Equal(5, result.TotalItems);
+        Assert.Equal(2, result.ItemsPerPage);
+        Assert.Equal(0, result.ActualPage);
+        Assert.Equal(3, result.TotalPages);
+        Assert.Equal(new[] { 1, 2 }, result.Data.Select(i => i.Id));
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_ReturnsPartialLastPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 2);
+
+        Assert.Single(result.Data);
+        Assert.Equal(5, result.Data.Single().Id);
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_PastLastPage_ReturnsEmptyButKeepsTotals()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 2, pageIndex: 10);
+
+        Assert.Empty(result.Data);
+        Assert.Equal(5, result.TotalItems);
+    }
+
+    [Fact]
+    public void GetCatalogItemsPaginated_IncludesBrandAndTypeNavigations()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = service.GetCatalogItemsPaginated(pageSize: 5, pageIndex: 0);
+
+        Assert.All(result.Data, item =>
+        {
+            Assert.NotNull(item.CatalogBrand);
+            Assert.NotNull(item.CatalogType);
+        });
+    }
+
+    [Fact]
+    public async Task GetCatalogItemsPaginatedAsync_ReturnsRequestedPage()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var result = await service.GetCatalogItemsPaginatedAsync(pageSize: 3, pageIndex: 0);
+
+        Assert.Equal(5, result.TotalItems);
+        Assert.Equal(3, result.Data.Count());
+        Assert.Equal(new[] { 1, 2, 3 }, result.Data.Select(i => i.Id));
+    }
+
+    [Fact]
+    public void FindCatalogItem_ExistingId_ReturnsItemWithNavigations()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var item = service.FindCatalogItem(3);
+
+        Assert.NotNull(item);
+        Assert.Equal(3, item!.Id);
+        Assert.Equal("Item 3", item.Name);
+        Assert.NotNull(item.CatalogBrand);
+        Assert.NotNull(item.CatalogType);
+    }
+
+    [Fact]
+    public void FindCatalogItem_UnknownId_ReturnsNull()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        Assert.Null(service.FindCatalogItem(999));
+    }
+
+    [Fact]
+    public async Task FindCatalogItemAsync_ExistingId_ReturnsItem()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var item = await service.FindCatalogItemAsync(1);
+
+        Assert.NotNull(item);
+        Assert.Equal(1, item!.Id);
+    }
+
+    [Fact]
+    public void GetCatalogBrands_ReturnsAllSeededBrands()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var brands = service.GetCatalogBrands().ToList();
+
+        Assert.Equal(2, brands.Count);
+        Assert.Contains(brands, b => b.Brand == "Azure");
+        Assert.Contains(brands, b => b.Brand == ".NET");
+    }
+
+    [Fact]
+    public async Task GetCatalogBrandsAsync_ReturnsAllSeededBrands()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var brands = await service.GetCatalogBrandsAsync();
+
+        Assert.Equal(2, brands.Count());
+    }
+
+    [Fact]
+    public void GetCatalogTypes_ReturnsAllSeededTypes()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var types = service.GetCatalogTypes().ToList();
+
+        Assert.Equal(2, types.Count);
+        Assert.Contains(types, t => t.Type == "Mug");
+        Assert.Contains(types, t => t.Type == "T-Shirt");
+    }
+
+    [Fact]
+    public async Task GetCatalogTypesAsync_ReturnsAllSeededTypes()
+    {
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var types = await service.GetCatalogTypesAsync();
+
+        Assert.Equal(2, types.Count());
+    }
+
+    [Fact]
+    public void UpdateCatalogItem_PersistsChangedFields()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var edited = new CatalogItem
+            {
+                Id = 2,
+                Name = "Renamed",
+                Description = "Updated description",
+                Price = 42.5M,
+                PictureFileName = "2.png",
+                CatalogBrandId = 1,
+                CatalogTypeId = 1,
+                AvailableStock = 7
+            };
+
+            service.UpdateCatalogItem(edited);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        var stored = verify.CatalogItems.Single(i => i.Id == 2);
+        Assert.Equal("Renamed", stored.Name);
+        Assert.Equal(42.5M, stored.Price);
+        Assert.Equal(7, stored.AvailableStock);
+    }
+
+    [Fact]
+    public async Task UpdateCatalogItemAsync_PersistsChangedFields()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var edited = new CatalogItem
+            {
+                Id = 4,
+                Name = "Async Renamed",
+                Price = 99M,
+                PictureFileName = "4.png",
+                CatalogBrandId = 1,
+                CatalogTypeId = 1
+            };
+
+            await service.UpdateCatalogItemAsync(edited);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Equal("Async Renamed", verify.CatalogItems.Single(i => i.Id == 4).Name);
+    }
+
+    [Fact]
+    public void RemoveCatalogItem_DeletesItemFromStore()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var toRemove = service.FindCatalogItem(1);
+            Assert.NotNull(toRemove);
+            service.RemoveCatalogItem(toRemove!);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Null(verify.CatalogItems.FirstOrDefault(i => i.Id == 1));
+        Assert.Equal(4, verify.CatalogItems.Count());
+    }
+
+    [Fact]
+    public async Task RemoveCatalogItemAsync_DeletesItemFromStore()
+    {
+        var options = NewOptions();
+        Seed(options);
+
+        using (var service = NewService(options))
+        {
+            var toRemove = await service.FindCatalogItemAsync(5);
+            Assert.NotNull(toRemove);
+            await service.RemoveCatalogItemAsync(toRemove!);
+        }
+
+        using var verify = new CatalogDBContext(options);
+        Assert.Null(verify.CatalogItems.FirstOrDefault(i => i.Id == 5));
+    }
+
+    [Fact]
+    public void CreateCatalogItem_WithInMemoryProvider_ThrowsBecauseHiLoNeedsSql()
+    {
+        // Documents the boundary: CreateCatalogItem delegates id assignment to
+        // CatalogItemHiLoGenerator, which runs a raw SQL sequence query. The
+        // in-memory provider exposes no relational connection, so this path is
+        // not unit-testable end-to-end without a real SQL Server.
+        var options = NewOptions();
+        Seed(options);
+        using var service = NewService(options);
+
+        var newItem = new CatalogItem
+        {
+            Name = "New",
+            Price = 1M,
+            PictureFileName = "new.png",
+            CatalogBrandId = 1,
+            CatalogTypeId = 1
+        };
+
+        Assert.ThrowsAny<Exception>(() => service.CreateCatalogItem(newItem));
+    }
+}


### PR DESCRIPTION
## Summary

Adds hermetic xUnit coverage for the database-backed catalog logic in `eShopCoreModernized`. Two new test files, no changes to `src/`, the `.csproj`, the `.sln`, or the existing `CatalogServiceMockTests.cs`. `dotnet test` is fully green: **26 passed** (22 new + 4 existing).

Classes covered:
- `Services/CatalogService.cs`
- `Models/CatalogItemHiLoGenerator.cs`

### `CatalogServiceTests.cs`
Drives a real `CatalogDBContext` on the EF Core **InMemory** provider. Each test uses an isolated database (`UseInMemoryDatabase(Guid.NewGuid())`) seeded with brands/types/items; write-then-read tests use a fresh context per operation so assertions reflect the store, not the change tracker. Covers (sync + async where applicable):
- pagination — requested page, partial last page, past-the-end (empty but totals preserved), and `Include` of brand/type navigations
- find — existing id (with navigations) and unknown id → null
- `GetCatalogBrands` / `GetCatalogTypes`
- update — persists changed fields
- remove — deletes from the store

### `CatalogItemHiLoGeneratorTests.cs`
Exercises the in-memory bookkeeping of the HiLo generator: once a block is reserved it hands out `HiLoIncrement` consecutive ids without touching the DB. Covers single increment, a full warm block draining `remainningLoIds` to 0, the async wrapper, fallback-to-DB when the block is exhausted, and thread-safety under `Parallel.For` (unique + contiguous ids).

## Not unit-testable without SQL Server (documented, not worked around)
`CatalogItemHiLoGenerator` issues a raw `SELECT NEXT VALUE FOR catalog_hilo` against the DB connection when its lo-id block is exhausted (the "cold" path). The InMemory provider has no relational connection, so:
- The cold path (fetching a fresh block) cannot be exercised end-to-end here — it requires a real SQL Server.
- `CatalogService.CreateCatalogItem`/`CreateCatalogItemAsync` delegate id assignment to that generator, so the create path is likewise not testable on InMemory. This boundary is pinned by `CreateCatalogItem_WithInMemoryProvider_ThrowsBecauseHiLoNeedsSql` and `GetNextSequenceValue_ExhaustedWarmBlock_FallsBackToDatabase`, which assert the DB is consulted (throws with a null/InMemory context) rather than silently reusing stale state.

To reach the generator's warm path deterministically without a database, the tests pre-seed the private `sequenceId`/`remainningLoIds` fields via reflection (the warm path never dereferences `db`, so a null context proves no DB access occurs). This is confined to the generator tests and documented in the file header.

## Bugs found
None. `src/` left untouched.


Link to Devin session: https://app.devin.ai/sessions/f3ecab15cb6b450ca9eed6acd378cd45
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/58?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->