### PR TITLE
test: add xUnit tests for MVC controllers

### DIFF
--- a/eShopModernized/tests/eShopModernized.Tests/AccountControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/AccountControllerTests.cs
@@ -1,0 +1,126 @@
+using System.Security.Claims;
+using eShopCoreModernized.Controllers;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class AccountControllerTests
+{
+    private readonly Mock<IAuthenticationService> _authService = new();
+
+    private AccountController CreateController(bool treatReturnUrlAsLocal = true)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_authService.Object);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        var controller = new AccountController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+            TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>()),
+        };
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(u => u.IsLocalUrl(It.IsAny<string>())).Returns(treatReturnUrlAsLocal);
+        controller.Url = urlHelper.Object;
+
+        return controller;
+    }
+
+    [Fact]
+    public void Login_Get_ReturnsViewWithReturnUrlInViewData()
+    {
+        var controller = CreateController();
+
+        var result = controller.Login("/protected");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("/protected", controller.ViewData["ReturnUrl"]);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithValidCredentials_SignsInAndRedirectsToCatalog()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Login("alice", "secret");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+        _authService.Verify(a => a.SignInAsync(
+            It.IsAny<HttpContext>(),
+            "Cookies",
+            It.Is<ClaimsPrincipal>(p => p.HasClaim(ClaimTypes.Name, "alice")),
+            It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithLocalReturnUrl_RedirectsToReturnUrl()
+    {
+        var controller = CreateController(treatReturnUrlAsLocal: true);
+
+        var result = await controller.Login("alice", "secret", "/dashboard");
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/dashboard", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Login_Post_WithNonLocalReturnUrl_RedirectsToCatalog()
+    {
+        var controller = CreateController(treatReturnUrlAsLocal: false);
+
+        var result = await controller.Login("alice", "secret", "http://evil.example.com");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+    }
+
+    [Theory]
+    [InlineData("", "secret")]
+    [InlineData("alice", "")]
+    [InlineData("", "")]
+    public async Task Login_Post_WithMissingCredentials_ReturnsViewWithError(string username, string password)
+    {
+        var controller = CreateController();
+
+        var result = await controller.Login(username, password, "/back");
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("Invalid username or password", controller.ViewData["Error"]);
+        Assert.Equal("/back", controller.ViewData["ReturnUrl"]);
+        _authService.Verify(a => a.SignInAsync(
+            It.IsAny<HttpContext>(), It.IsAny<string>(),
+            It.IsAny<ClaimsPrincipal>(), It.IsAny<AuthenticationProperties>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Logout_SignsOutAndRedirectsToCatalog()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Logout();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal("Catalog", redirect.ControllerName);
+        _authService.Verify(a => a.SignOutAsync(
+            It.IsAny<HttpContext>(), "Cookies", It.IsAny<AuthenticationProperties>()), Times.Once);
+    }
+
+    [Fact]
+    public void AccessDenied_ReturnsView()
+    {
+        var result = CreateController().AccessDenied();
+
+        Assert.IsType<ViewResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/BrandsControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/BrandsControllerTests.cs
@@ -1,0 +1,77 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class BrandsControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+
+    private BrandsController CreateController() =>
+        new(_service.Object, NullLogger<BrandsController>.Instance);
+
+    private static List<CatalogBrand> SampleBrands() => new()
+    {
+        new CatalogBrand { Id = 1, Brand = "Azure" },
+        new CatalogBrand { Id = 2, Brand = "Visual Studio" },
+    };
+
+    [Fact]
+    public async Task Get_ReturnsOkWithAllBrands()
+    {
+        var brands = SampleBrands();
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(brands);
+
+        var result = await CreateController().Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Same(brands, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetById_WithExistingId_ReturnsOkWithBrand()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Get(2);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var brand = Assert.IsType<CatalogBrand>(ok.Value);
+        Assert.Equal(2, brand.Id);
+        Assert.Equal("Visual Studio", brand.Brand);
+    }
+
+    [Fact]
+    public async Task GetById_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Get(999);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Delete_WithExistingId_ReturnsOk()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Delete(1);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(SampleBrands());
+
+        var result = await CreateController().Delete(999);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/CatalogControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/CatalogControllerTests.cs
@@ -1,0 +1,269 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.ViewModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class CatalogControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<IImageService> _imageService = new();
+    private readonly Mock<ICatalogConfiguration> _config = new();
+
+    private CatalogController CreateController() =>
+        new(_service.Object, _imageService.Object, _config.Object, NullLogger<CatalogController>.Instance);
+
+    private static CatalogItem NewItem(int id, string name = "Item") =>
+        new() { Id = id, Name = name, PictureFileName = "pic.png" };
+
+    [Fact]
+    public async Task Index_ReturnsViewWithPaginatedItems_AndBuildsImageUris()
+    {
+        var items = new[] { NewItem(1), NewItem(2) };
+        var paginated = new PaginatedItemsViewModel<CatalogItem>(0, 10, 2, items);
+        _service.Setup(s => s.GetCatalogItemsPaginatedAsync(10, 0)).ReturnsAsync(paginated);
+        _imageService.Setup(i => i.BuildUrlImage(It.IsAny<CatalogItem>())).Returns("http://img/x.png");
+        var controller = CreateController();
+
+        var result = await controller.Index();
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(paginated, view.Model);
+        _imageService.Verify(i => i.BuildUrlImage(It.IsAny<CatalogItem>()), Times.Exactly(2));
+        Assert.All(items, i => Assert.Equal("http://img/x.png", i.PictureUri));
+    }
+
+    [Fact]
+    public async Task Details_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Details(null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Details_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(99)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Details(99);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Details_WithValidId_ReturnsViewWithItemAndImageUri()
+    {
+        var item = NewItem(3);
+        _service.Setup(s => s.FindCatalogItemAsync(3)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/3.png");
+
+        var result = await CreateController().Details(3);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        Assert.Equal("http://img/3.png", item.PictureUri);
+    }
+
+    [Fact]
+    public async Task Create_Get_ReturnsViewWithDefaultImageAndPopulatesViewBag()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        _imageService.Setup(i => i.UrlDefaultImage()).Returns("default.png");
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+        var controller = CreateController();
+
+        var result = await controller.Create();
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<CatalogItem>(view.Model);
+        Assert.Equal("default.png", model.PictureUri);
+        Assert.Equal(true, controller.ViewBag.UseAzureStorage);
+        Assert.NotNull(controller.ViewBag.CatalogBrandId);
+        Assert.NotNull(controller.ViewBag.CatalogTypeId);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithValidModel_CreatesItemAndRedirectsToIndex()
+    {
+        var item = NewItem(0, "New");
+        var controller = CreateController();
+
+        var result = await controller.Create(item);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithTempImage_UpdatesImageAndSetsPictureFileName()
+    {
+        var item = NewItem(0, "New");
+        item.TempImageName = "/tmp/uploaded.png";
+        var controller = CreateController();
+
+        var result = await controller.Create(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("uploaded.png", item.PictureFileName);
+        _service.Verify(s => s.CreateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreatePost_WithInvalidModel_ReturnsViewWithItem()
+    {
+        var item = NewItem(0, "New");
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+
+        var result = await controller.Create(item);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.CreateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Edit((int?)null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(42)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Edit(42);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Edit_Get_WithValidId_ReturnsViewWithItem()
+    {
+        var item = NewItem(5);
+        _service.Setup(s => s.FindCatalogItemAsync(5)).ReturnsAsync(item);
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/5.png");
+
+        var result = await CreateController().Edit(5);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task EditPost_WithValidModel_UpdatesItemAndRedirectsToIndex()
+    {
+        var item = NewItem(6, "Edited");
+        var controller = CreateController();
+
+        var result = await controller.Edit(item);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+        _imageService.Verify(i => i.UpdateImageAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EditPost_WithTempImage_UpdatesImageAndSetsPictureFileName()
+    {
+        var item = NewItem(7, "Edited");
+        item.TempImageName = "/tmp/new.png";
+        var controller = CreateController();
+
+        var result = await controller.Edit(item);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("new.png", item.PictureFileName);
+        _imageService.Verify(i => i.UpdateImageAsync(item), Times.Once);
+        _service.Verify(s => s.UpdateCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task EditPost_WithInvalidModel_ReturnsViewWithoutUpdating()
+    {
+        var item = NewItem(8, "Edited");
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+        _service.Setup(s => s.GetCatalogTypesAsync()).ReturnsAsync(new List<CatalogType>());
+        var controller = CreateController();
+        controller.ModelState.AddModelError("Name", "Required");
+
+        var result = await controller.Edit(item);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+        _service.Verify(s => s.UpdateCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithNullId_ReturnsBadRequest()
+    {
+        var result = await CreateController().Delete((int?)null);
+
+        Assert.IsType<BadRequestResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithUnknownId_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(11)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Delete(11);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_Get_WithValidId_ReturnsViewWithItem()
+    {
+        var item = NewItem(12);
+        _service.Setup(s => s.FindCatalogItemAsync(12)).ReturnsAsync(item);
+        _imageService.Setup(i => i.BuildUrlImage(item)).Returns("http://img/12.png");
+
+        var result = await CreateController().Delete(12);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Same(item, view.Model);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithExistingItem_RemovesAndRedirectsToIndex()
+    {
+        var item = NewItem(13);
+        _service.Setup(s => s.FindCatalogItemAsync(13)).ReturnsAsync(item);
+
+        var result = await CreateController().DeleteConfirmed(13);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(CatalogController.Index), redirect.ActionName);
+        _service.Verify(s => s.RemoveCatalogItemAsync(item), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteConfirmed_WithMissingItem_RedirectsWithoutRemoving()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(14)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().DeleteConfirmed(14);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        _service.Verify(s => s.RemoveCatalogItemAsync(It.IsAny<CatalogItem>()), Times.Never);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/FilesControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/FilesControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Text.Json;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class FilesControllerTests
+{
+    private readonly Mock<ICatalogService> _service = new();
+
+    private FilesController CreateController() =>
+        new(_service.Object, NullLogger<FilesController>.Instance);
+
+    [Fact]
+    public async Task Get_ReturnsJsonFileWithBrands()
+    {
+        var brands = new List<CatalogBrand>
+        {
+            new() { Id = 1, Brand = "Azure" },
+            new() { Id = 2, Brand = "Visual Studio" },
+        };
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(brands);
+
+        var result = await CreateController().Get();
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("application/json", file.ContentType);
+
+        var json = Encoding.UTF8.GetString(file.FileContents);
+        var deserialized = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(json);
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized!.Count);
+        Assert.Equal("Azure", deserialized[0].Brand);
+        Assert.Equal(2, deserialized[1].Id);
+    }
+
+    [Fact]
+    public async Task Get_WithNoBrands_ReturnsEmptyJsonArrayFile()
+    {
+        _service.Setup(s => s.GetCatalogBrandsAsync()).ReturnsAsync(new List<CatalogBrand>());
+
+        var result = await CreateController().Get();
+
+        var file = Assert.IsType<FileContentResult>(result);
+        var json = Encoding.UTF8.GetString(file.FileContents);
+        var deserialized = JsonSerializer.Deserialize<List<FilesController.BrandDTO>>(json);
+        Assert.NotNull(deserialized);
+        Assert.Empty(deserialized!);
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/HealthControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/HealthControllerTests.cs
@@ -1,0 +1,87 @@
+using eShopCoreModernized.Configuration;
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class HealthControllerTests : IDisposable
+{
+    private readonly Mock<ICatalogConfiguration> _config = new();
+    private readonly CatalogDBContext _dbContext;
+
+    public HealthControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDBContext>()
+            .UseInMemoryDatabase("health-" + Guid.NewGuid().ToString("N"))
+            .Options;
+        _dbContext = new CatalogDBContext(options);
+    }
+
+    private HealthController CreateController() =>
+        new(_config.Object, _dbContext, NullLogger<HealthController>.Instance);
+
+    private static T? ReadProp<T>(object? value, string name) =>
+        (T?)value?.GetType().GetProperty(name)?.GetValue(value);
+
+    private static object? ReadService(object? servicesValue, string key)
+    {
+        var services = Assert.IsAssignableFrom<IDictionary<string, object>>(servicesValue);
+        return services.TryGetValue(key, out var entry) ? entry : null;
+    }
+
+    [Fact]
+    public void Get_ReturnsOkWithHealthyStatus()
+    {
+        var result = CreateController().Get();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Healthy", ReadProp<string>(ok.Value, "status"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_ReturnsOkWithStatusAndVersion()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Healthy", ReadProp<string>(ok.Value, "status"));
+        Assert.False(string.IsNullOrEmpty(ReadProp<string>(ok.Value, "version")));
+        Assert.NotNull(ReadProp<object>(ok.Value, "services"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_WhenDatabaseReachable_ReportsHealthyDatabase()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(false);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var services = ReadProp<object>(ok.Value, "services");
+        var database = ReadService(services, "database");
+        Assert.NotNull(database);
+        Assert.Equal("Healthy", ReadProp<string>(database, "status"));
+    }
+
+    [Fact]
+    public async Task GetDetailed_WhenAzureStorageEnabledWithoutClient_ReportsNotConfigured()
+    {
+        _config.SetupGet(c => c.UseAzureStorage).Returns(true);
+
+        var result = await CreateController().GetDetailed();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var services = ReadProp<object>(ok.Value, "services");
+        var azure = ReadService(services, "azureStorage");
+        Assert.NotNull(azure);
+        Assert.Equal("NotConfigured", ReadProp<string>(azure, "status"));
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/eShopModernized/tests/eShopModernized.Tests/ImageUploadControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/ImageUploadControllerTests.cs
@@ -1,0 +1,95 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class ImageUploadControllerTests
+{
+    private readonly Mock<IImageService> _imageService = new();
+
+    private ImageUploadController CreateController() =>
+        new(_imageService.Object, NullLogger<ImageUploadController>.Instance);
+
+    private static IFormFile FakeFile(string fileName, long length)
+    {
+        var mock = new Mock<IFormFile>();
+        mock.SetupGet(f => f.FileName).Returns(fileName);
+        mock.SetupGet(f => f.Length).Returns(length);
+        return mock.Object;
+    }
+
+    private static string? ReadImageUrl(object? value) =>
+        value?.GetType().GetProperty("imageUrl")?.GetValue(value) as string;
+
+    [Fact]
+    public async Task UploadImage_WithValidPng_ReturnsOkWithImageUrl()
+    {
+        _imageService.Setup(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), 5))
+            .ReturnsAsync("http://img/temp.png");
+
+        var result = await CreateController().UploadImage(FakeFile("photo.png", 100), 5);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("http://img/temp.png", ReadImageUrl(ok.Value));
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), 5), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadImage_WithNullFile_ReturnsBadRequest()
+    {
+        var result = await CreateController().UploadImage(null!);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No file uploaded", bad.Value);
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadImage_WithEmptyFile_ReturnsBadRequest()
+    {
+        var result = await CreateController().UploadImage(FakeFile("photo.png", 0));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No file uploaded", bad.Value);
+    }
+
+    [Theory]
+    [InlineData("document.pdf")]
+    [InlineData("archive.zip")]
+    [InlineData("script.exe")]
+    public async Task UploadImage_WithDisallowedExtension_ReturnsBadRequest(string fileName)
+    {
+        var result = await CreateController().UploadImage(FakeFile(fileName, 100));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Invalid file type. Only JPG, PNG, and GIF files are allowed.", bad.Value);
+        _imageService.Verify(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadImage_WhenServiceThrows_Returns500()
+    {
+        _imageService.Setup(i => i.UploadTempImageAsync(It.IsAny<IFormFile>(), It.IsAny<int?>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await CreateController().UploadImage(FakeFile("photo.jpg", 100));
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, status.StatusCode);
+    }
+
+    [Fact]
+    public void GetDefaultImage_ReturnsOkWithDefaultImageUrl()
+    {
+        _imageService.Setup(i => i.UrlDefaultImage()).Returns("http://img/default.png");
+
+        var result = CreateController().GetDefaultImage();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("http://img/default.png", ReadImageUrl(ok.Value));
+    }
+}

--- a/eShopModernized/tests/eShopModernized.Tests/PicControllerTests.cs
+++ b/eShopModernized/tests/eShopModernized.Tests/PicControllerTests.cs
@@ -1,0 +1,104 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace eShopModernized.Tests;
+
+public class PicControllerTests : IDisposable
+{
+    private readonly Mock<ICatalogService> _service = new();
+    private readonly Mock<IWebHostEnvironment> _environment = new();
+    private readonly string _contentRoot;
+
+    public PicControllerTests()
+    {
+        _contentRoot = Path.Combine(Path.GetTempPath(), "pic-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_contentRoot);
+        _environment.SetupGet(e => e.WebRootPath).Returns(_contentRoot);
+        _environment.SetupGet(e => e.ContentRootPath).Returns(_contentRoot);
+    }
+
+    private PicController CreateController() =>
+        new(_service.Object, NullLogger<PicController>.Instance, _environment.Object);
+
+    private string CreatePicFile(string fileName, byte[] content)
+    {
+        var picsDir = Path.Combine(_contentRoot, "Pics");
+        Directory.CreateDirectory(picsDir);
+        var path = Path.Combine(picsDir, fileName);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Index_WithNonPositiveId_ReturnsBadRequest(int id)
+    {
+        var result = await CreateController().Index(id);
+
+        Assert.IsType<BadRequestResult>(result);
+        _service.Verify(s => s.FindCatalogItemAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Index_WithUnknownItem_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(7)).ReturnsAsync((CatalogItem?)null);
+
+        var result = await CreateController().Index(7);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Index_WhenPictureFileMissingOnDisk_ReturnsNotFound()
+    {
+        _service.Setup(s => s.FindCatalogItemAsync(8))
+            .ReturnsAsync(new CatalogItem { Id = 8, Name = "X", PictureFileName = "missing.png" });
+
+        var result = await CreateController().Index(8);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Index_WithExistingPictureFile_ReturnsFileWithCorrectMimeType()
+    {
+        var bytes = new byte[] { 1, 2, 3, 4 };
+        CreatePicFile("item9.png", bytes);
+        _service.Setup(s => s.FindCatalogItemAsync(9))
+            .ReturnsAsync(new CatalogItem { Id = 9, Name = "X", PictureFileName = "item9.png" });
+
+        var result = await CreateController().Index(9);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/png", file.ContentType);
+        Assert.Equal(bytes, file.FileContents);
+    }
+
+    [Fact]
+    public async Task Index_WithJpegPictureFile_ReturnsJpegMimeType()
+    {
+        CreatePicFile("item10.jpg", new byte[] { 9 });
+        _service.Setup(s => s.FindCatalogItemAsync(10))
+            .ReturnsAsync(new CatalogItem { Id = 10, Name = "X", PictureFileName = "item10.jpg" });
+
+        var result = await CreateController().Index(10);
+
+        var file = Assert.IsType<FileContentResult>(result);
+        Assert.Equal("image/jpeg", file.ContentType);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_contentRoot))
+        {
+            Directory.Delete(_contentRoot, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds unit tests for all seven MVC controllers in `eShopModernized/src/eShopCoreModernized/Controllers/`, following the conventions in the existing `CatalogServiceMockTests.cs`. Each controller is constructed directly with Moq mocks for its dependencies; tests assert on the returned `IActionResult` types, view models / payloads, and that the expected service methods are invoked. **53 new tests, all green** (`dotnet test` → 57 passed total). Only new `*ControllerTests.cs` files were added — no shared `.csproj`/`.sln`, no existing test, and no `src/` production code was touched.

### Coverage by class
- **CatalogControllerTests** — `Index` (paginated view + `BuildUrlImage` applied to every item), `Details`/`Edit`/`Delete` GET (null id → `BadRequest`, unknown id → `NotFound`, valid → `ViewResult`), `Create`/`Edit` POST (valid → `CreateCatalogItemAsync`/`UpdateCatalogItemAsync` + redirect to `Index`; `TempImageName` → `UpdateImageAsync` + `PictureFileName` set to the file name; invalid `ModelState` → view, no service call), `DeleteConfirmed` (existing → remove + redirect; missing → redirect, no remove).
- **BrandsControllerTests** — `Get` (all brands), `Get(id)` (found → `Ok`, unknown → `NotFound`), `Delete(id)` (found → `Ok`, unknown → `NotFound`).
- **FilesControllerTests** — `Get` returns a `application/json` `FileContentResult`; deserializes the bytes back to `BrandDTO`s (populated + empty cases).
- **ImageUploadControllerTests** — `UploadImage` happy path (`Ok` + `imageUrl`, service invoked), null/empty file → `BadRequest`, disallowed extensions (`[Theory]`) → `BadRequest` + no upload, service throws → `500`; `GetDefaultImage` → `Ok`.
- **PicControllerTests** — `Index` non-positive id → `BadRequest` (no lookup), unknown item → `NotFound`, missing file on disk → `NotFound`, existing file → `FileContentResult` with correct MIME (png/jpeg). Uses a real temp `Pics/` dir via a mocked `IWebHostEnvironment`, cleaned up in `Dispose`.
- **HealthControllerTests** — `Get` → `Ok` `status=Healthy`; `GetDetailed` → status/version/services, DB reachable via EF Core InMemory → database `Healthy`, `UseAzureStorage=true` without a `BlobServiceClient` → azureStorage `NotConfigured`.
- **AccountControllerTests** — `Login` GET (returnUrl in `ViewData`), `Login` POST (valid → `SignInAsync` with a `ClaimsPrincipal` + redirect to `Catalog/Index`; local returnUrl → `Redirect`; non-local → `Catalog/Index`; missing creds (`[Theory]`) → view with error, no sign-in), `Logout` → `SignOutAsync` + redirect, `AccessDenied` → view.

### Test approach notes
- Tests are hermetic and fast: EF Core InMemory for `CatalogDBContext` (Health), Moq for all interfaces, `NullLogger<T>` for loggers, a temp directory for `PicController` file reads. No SQL Server / Azure.
- Anonymous-object payloads (`Health`, `ImageUpload`) are read via small reflection helpers; `HealthController.GetDetailed`'s `services` value is a `Dictionary<string, object>` and is read by key.
- `AccountController` needs an `IAuthenticationService` in `HttpContext.RequestServices` (for the `SignInAsync`/`SignOutAsync` extensions), a mocked `IUrlHelper` (to control `Url.IsLocalUrl`), and `TempData` (required by `View()`); all are wired up in a small helper.

### Bugs found
None — no production code changes were needed.


Link to Devin session: https://app.devin.ai/sessions/4927874d6d8f4c3984c5b33aae675786
Requested by: @georgewduffy
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/59?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->