### PR TITLE
Strangler-fig slice: port catalog brands management to eShopCoreModernized (.NET 8)

### DIFF
--- a/eShopModernized/eShopModernized.sln
+++ b/eShopModernized/eShopModernized.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9AFA2E77-0E16-4ED3-844D-D305E0E8C2BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopModernized", "src\eShopCoreModernized\eShopModernized.csproj", "{EE8738A0-F19A-437B-93E0-CE28DB67BA26}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{25920B94-FCF4-49C7-B306-91038CB81F8C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopCoreModernized.Tests", "tests\eShopCoreModernized.Tests\eShopCoreModernized.Tests.csproj", "{BB30F7A3-8CD5-414B-878E-DD88FB60B709}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EE8738A0-F19A-437B-93E0-CE28DB67BA26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE8738A0-F19A-437B-93E0-CE28DB67BA26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE8738A0-F19A-437B-93E0-CE28DB67BA26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE8738A0-F19A-437B-93E0-CE28DB67BA26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB30F7A3-8CD5-414B-878E-DD88FB60B709}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB30F7A3-8CD5-414B-878E-DD88FB60B709}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB30F7A3-8CD5-414B-878E-DD88FB60B709}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB30F7A3-8CD5-414B-878E-DD88FB60B709}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EE8738A0-F19A-437B-93E0-CE28DB67BA26} = {9AFA2E77-0E16-4ED3-844D-D305E0E8C2BA}
+		{BB30F7A3-8CD5-414B-878E-DD88FB60B709} = {25920B94-FCF4-49C7-B306-91038CB81F8C}
+	EndGlobalSection
+EndGlobal

--- a/eShopModernized/src/eShopCoreModernized/Controllers/Api/BrandsApiController.cs
+++ b/eShopModernized/src/eShopCoreModernized/Controllers/Api/BrandsApiController.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc;
+using eShopCoreModernized.Services;
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Controllers.Api
+{
+    [Route("api/brands")]
+    [ApiController]
+    public class BrandsApiController : ControllerBase
+    {
+        private readonly IBrandService _service;
+        private readonly ILogger<BrandsApiController> _logger;
+
+        public BrandsApiController(IBrandService service, ILogger<BrandsApiController> logger)
+        {
+            _service = service;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CatalogBrand>>> Get()
+        {
+            var brands = await _service.GetBrandsAsync();
+            return Ok(brands);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CatalogBrand>> Get(int id)
+        {
+            var brand = await _service.FindBrandAsync(id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(brand);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CatalogBrand>> Post([FromBody] CatalogBrand brand)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            _logger.LogInformation("Now processing... POST /api/brands?brand={Brand}", brand.Brand);
+            await _service.CreateBrandAsync(brand);
+
+            return CreatedAtAction(nameof(Get), new { id = brand.Id }, brand);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Put(int id, [FromBody] CatalogBrand brand)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var existing = await _service.FindBrandAsync(id);
+            if (existing == null)
+            {
+                return NotFound();
+            }
+
+            _logger.LogInformation("Now processing... PUT /api/brands/{Id}", id);
+            existing.Brand = brand.Brand;
+            await _service.UpdateBrandAsync(existing);
+
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var brandToDelete = await _service.FindBrandAsync(id);
+            if (brandToDelete == null)
+            {
+                return NotFound();
+            }
+
+            if (await _service.IsBrandInUseAsync(id))
+            {
+                return Conflict($"Brand {id} is still referenced by catalog items.");
+            }
+
+            _logger.LogInformation("Now processing... DELETE /api/brands/{Id}", id);
+            await _service.RemoveBrandAsync(brandToDelete);
+
+            return NoContent();
+        }
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Controllers/BrandsController.cs
+++ b/eShopModernized/src/eShopCoreModernized/Controllers/BrandsController.cs
@@ -1,55 +1,143 @@
 using Microsoft.AspNetCore.Mvc;
-using eShopCoreModernized.Services;
+using Microsoft.AspNetCore.Authorization;
 using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
 
 namespace eShopCoreModernized.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class BrandsController : ControllerBase
+    public class BrandsController : Controller
     {
-        private readonly ICatalogService _service;
+        private readonly IBrandService _service;
         private readonly ILogger<BrandsController> _logger;
 
-        public BrandsController(ICatalogService service, ILogger<BrandsController> logger)
+        public BrandsController(IBrandService service, ILogger<BrandsController> logger)
         {
             _service = service;
             _logger = logger;
         }
 
-        [HttpGet]
-        public async Task<ActionResult<IEnumerable<CatalogBrand>>> Get()
+        public async Task<IActionResult> Index()
         {
-            var brands = await _service.GetCatalogBrandsAsync();
-            return Ok(brands);
+            _logger.LogInformation("Now loading... /Brands/Index");
+            return View(await _service.GetBrandsAsync());
         }
 
-        [HttpGet("{id}")]
-        public async Task<ActionResult<CatalogBrand>> Get(int id)
+        public async Task<IActionResult> Details(int? id)
         {
-            var brands = await _service.GetCatalogBrandsAsync();
-            var brand = brands.FirstOrDefault(x => x.Id == id);
-            
+            _logger.LogInformation("Now loading... /Brands/Details?id={Id}", id);
+            if (id == null)
+            {
+                return BadRequest();
+            }
+            var brand = await _service.FindBrandAsync(id.Value);
             if (brand == null)
             {
                 return NotFound();
             }
 
-            return Ok(brand);
+            return View(brand);
         }
 
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(int id)
+        [Authorize]
+        public IActionResult Create()
         {
-            var brands = await _service.GetCatalogBrandsAsync();
-            var brandToDelete = brands.FirstOrDefault(x => x.Id == id);
-            
-            if (brandToDelete == null)
+            _logger.LogInformation("Now loading... /Brands/Create");
+            return View(new CatalogBrand());
+        }
+
+        [HttpPost]
+        [Authorize]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("Brand")] CatalogBrand catalogBrand)
+        {
+            _logger.LogInformation("Now processing... /Brands/Create?brand={Brand}", catalogBrand.Brand);
+            if (!ModelState.IsValid)
+            {
+                return View(catalogBrand);
+            }
+
+            await _service.CreateBrandAsync(catalogBrand);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [Authorize]
+        public async Task<IActionResult> Edit(int? id)
+        {
+            _logger.LogInformation("Now loading... /Brands/Edit?id={Id}", id);
+            if (id == null)
+            {
+                return BadRequest();
+            }
+            var brand = await _service.FindBrandAsync(id.Value);
+            if (brand == null)
             {
                 return NotFound();
             }
 
-            return Ok();
+            return View(brand);
+        }
+
+        [HttpPost]
+        [Authorize]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit([Bind("Id,Brand")] CatalogBrand catalogBrand)
+        {
+            _logger.LogInformation("Now processing... /Brands/Edit?id={Id}", catalogBrand.Id);
+            if (!ModelState.IsValid)
+            {
+                return View(catalogBrand);
+            }
+
+            var existing = await _service.FindBrandAsync(catalogBrand.Id);
+            if (existing == null)
+            {
+                return NotFound();
+            }
+
+            existing.Brand = catalogBrand.Brand;
+            await _service.UpdateBrandAsync(existing);
+            return RedirectToAction(nameof(Index));
+        }
+
+        [Authorize]
+        public async Task<IActionResult> Delete(int? id)
+        {
+            _logger.LogInformation("Now loading... /Brands/Delete?id={Id}", id);
+            if (id == null)
+            {
+                return BadRequest();
+            }
+            var brand = await _service.FindBrandAsync(id.Value);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+            ViewBag.IsBrandInUse = await _service.IsBrandInUseAsync(id.Value);
+
+            return View(brand);
+        }
+
+        [HttpPost, ActionName("Delete")]
+        [Authorize]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            _logger.LogInformation("Now processing... /Brands/DeleteConfirmed?id={Id}", id);
+            var brand = await _service.FindBrandAsync(id);
+            if (brand == null)
+            {
+                return NotFound();
+            }
+
+            if (await _service.IsBrandInUseAsync(id))
+            {
+                ModelState.AddModelError(string.Empty, "This brand cannot be deleted while catalog items still reference it.");
+                ViewBag.IsBrandInUse = true;
+                return View(brand);
+            }
+
+            await _service.RemoveBrandAsync(brand);
+            return RedirectToAction(nameof(Index));
         }
     }
 }

--- a/eShopModernized/src/eShopCoreModernized/Models/CatalogBrand.cs
+++ b/eShopModernized/src/eShopCoreModernized/Models/CatalogBrand.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace eShopCoreModernized.Models
 {
     public class CatalogBrand
     {
         public int Id { get; set; }
+
+        [Required]
+        [StringLength(100)]
         public string Brand { get; set; } = string.Empty;
     }
 }

--- a/eShopModernized/src/eShopCoreModernized/Models/CatalogBrandHiLoGenerator.cs
+++ b/eShopModernized/src/eShopCoreModernized/Models/CatalogBrandHiLoGenerator.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopCoreModernized.Models
+{
+    public class CatalogBrandHiLoGenerator : IBrandIdGenerator
+    {
+        private const int HiLoIncrement = 10;
+        private int sequenceId = -1;
+        private int remainningLoIds = 0;
+        private readonly object sequenceLock = new object();
+
+        public async Task<int> GetNextSequenceValueAsync(CatalogDBContext db)
+        {
+            return await Task.Run(() => GetNextSequenceValue(db));
+        }
+
+        public int GetNextSequenceValue(CatalogDBContext db)
+        {
+            lock (sequenceLock)
+            {
+                if (remainningLoIds == 0)
+                {
+                    var connection = db.Database.GetDbConnection();
+                    connection.Open();
+                    using var command = connection.CreateCommand();
+                    command.CommandText = "SELECT NEXT VALUE FOR catalog_brand_hilo;";
+                    var result = command.ExecuteScalar();
+                    sequenceId = Convert.ToInt32(result);
+                    remainningLoIds = HiLoIncrement - 1;
+                    return sequenceId;
+                }
+                else
+                {
+                    remainningLoIds--;
+                    return ++sequenceId;
+                }
+            }
+        }
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Models/IBrandIdGenerator.cs
+++ b/eShopModernized/src/eShopCoreModernized/Models/IBrandIdGenerator.cs
@@ -1,0 +1,7 @@
+namespace eShopCoreModernized.Models
+{
+    public interface IBrandIdGenerator
+    {
+        Task<int> GetNextSequenceValueAsync(CatalogDBContext db);
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Program.cs
+++ b/eShopModernized/src/eShopCoreModernized/Program.cs
@@ -48,10 +48,12 @@ else
 if (catalogConfig.UseMockData)
 {
     builder.Services.AddSingleton<ICatalogService, CatalogServiceMock>();
+    builder.Services.AddSingleton<IBrandService, BrandServiceMock>();
 }
 else
 {
     builder.Services.AddScoped<ICatalogService, CatalogService>();
+    builder.Services.AddScoped<IBrandService, BrandService>();
 }
 
 if (catalogConfig.UseAzureStorage)
@@ -69,6 +71,7 @@ else
 }
 
 builder.Services.AddSingleton<CatalogItemHiLoGenerator>();
+builder.Services.AddSingleton<IBrandIdGenerator, CatalogBrandHiLoGenerator>();
 
 if (catalogConfig.UseAzureActiveDirectory)
 {

--- a/eShopModernized/src/eShopCoreModernized/README.md
+++ b/eShopModernized/src/eShopCoreModernized/README.md
@@ -123,8 +123,19 @@ This .NET Core application is designed to gradually replace the legacy system:
 - **Microsoft.ApplicationInsights.AspNetCore**: Telemetry and monitoring
 - **Microsoft.Identity.Web**: Azure AD authentication
 
+## Brands management (strangler-fig slice)
+
+Catalog brand reference data is owned by this application:
+
+- `/Brands` — MVC list/details/create/edit/delete screens (write actions require sign-in).
+- `/api/brands` — `GET`, `GET/{id}`, `POST`, `PUT/{id}`, `DELETE/{id}`. Deleting a brand that catalog
+  items still reference returns `409 Conflict`, matching the legacy foreign key constraint.
+- New brand ids come from the `catalog_brand_hilo` SQL sequence created by the legacy database
+  initializer, so ids stay compatible with the legacy application writing to the same database.
+
 ## Testing
 
+Unit tests live in `eShopModernized/tests/eShopCoreModernized.Tests` and run with `dotnet test`.
 The application includes comprehensive logging and can be tested locally with mock services or against real Azure services depending on configuration.
 
 ## Migration from Legacy System

--- a/eShopModernized/src/eShopCoreModernized/Services/BrandService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/BrandService.cs
@@ -1,0 +1,51 @@
+using eShopCoreModernized.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopCoreModernized.Services
+{
+    public class BrandService : IBrandService
+    {
+        private readonly CatalogDBContext db;
+        private readonly IBrandIdGenerator indexGenerator;
+
+        public BrandService(CatalogDBContext db, IBrandIdGenerator indexGenerator)
+        {
+            this.db = db;
+            this.indexGenerator = indexGenerator;
+        }
+
+        public async Task<IEnumerable<CatalogBrand>> GetBrandsAsync()
+        {
+            return await db.CatalogBrands.OrderBy(b => b.Id).ToListAsync();
+        }
+
+        public async Task<CatalogBrand?> FindBrandAsync(int id)
+        {
+            return await db.CatalogBrands.FirstOrDefaultAsync(b => b.Id == id);
+        }
+
+        public async Task CreateBrandAsync(CatalogBrand brand)
+        {
+            brand.Id = await indexGenerator.GetNextSequenceValueAsync(db);
+            db.CatalogBrands.Add(brand);
+            await db.SaveChangesAsync();
+        }
+
+        public async Task UpdateBrandAsync(CatalogBrand brand)
+        {
+            db.Entry(brand).State = EntityState.Modified;
+            await db.SaveChangesAsync();
+        }
+
+        public async Task RemoveBrandAsync(CatalogBrand brand)
+        {
+            db.CatalogBrands.Remove(brand);
+            await db.SaveChangesAsync();
+        }
+
+        public async Task<bool> IsBrandInUseAsync(int id)
+        {
+            return await db.CatalogItems.AnyAsync(i => i.CatalogBrandId == id);
+        }
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Services/BrandServiceMock.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/BrandServiceMock.cs
@@ -1,0 +1,59 @@
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Services
+{
+    public class BrandServiceMock : IBrandService
+    {
+        private readonly ICatalogService catalogService;
+        private readonly List<CatalogBrand> brands;
+
+        public BrandServiceMock(ICatalogService catalogService)
+        {
+            this.catalogService = catalogService;
+
+            // CatalogServiceMock hands back its live brand collection, so brand edits made
+            // here stay visible on the catalog item screens while running on mock data.
+            brands = catalogService.GetCatalogBrands() as List<CatalogBrand>
+                ?? catalogService.GetCatalogBrands().ToList();
+        }
+
+        public Task<IEnumerable<CatalogBrand>> GetBrandsAsync()
+        {
+            return Task.FromResult<IEnumerable<CatalogBrand>>(brands.OrderBy(b => b.Id).ToList());
+        }
+
+        public Task<CatalogBrand?> FindBrandAsync(int id)
+        {
+            return Task.FromResult(brands.FirstOrDefault(b => b.Id == id));
+        }
+
+        public Task CreateBrandAsync(CatalogBrand brand)
+        {
+            brand.Id = brands.Count == 0 ? 1 : brands.Max(b => b.Id) + 1;
+            brands.Add(brand);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateBrandAsync(CatalogBrand brand)
+        {
+            var existing = brands.FirstOrDefault(b => b.Id == brand.Id);
+            if (existing != null)
+            {
+                existing.Brand = brand.Brand;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveBrandAsync(CatalogBrand brand)
+        {
+            brands.RemoveAll(b => b.Id == brand.Id);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsBrandInUseAsync(int id)
+        {
+            var items = catalogService.GetCatalogItemsPaginated(int.MaxValue, 0);
+            return Task.FromResult(items.Data.Any(i => i.CatalogBrandId == id));
+        }
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Services/IBrandService.cs
+++ b/eShopModernized/src/eShopCoreModernized/Services/IBrandService.cs
@@ -1,0 +1,14 @@
+using eShopCoreModernized.Models;
+
+namespace eShopCoreModernized.Services
+{
+    public interface IBrandService
+    {
+        Task<IEnumerable<CatalogBrand>> GetBrandsAsync();
+        Task<CatalogBrand?> FindBrandAsync(int id);
+        Task CreateBrandAsync(CatalogBrand brand);
+        Task UpdateBrandAsync(CatalogBrand brand);
+        Task RemoveBrandAsync(CatalogBrand brand);
+        Task<bool> IsBrandInUseAsync(int id);
+    }
+}

--- a/eShopModernized/src/eShopCoreModernized/Views/Brands/Create.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Brands/Create.cshtml
@@ -1,0 +1,38 @@
+@model eShopCoreModernized.Models.CatalogBrand
+
+@{
+    ViewBag.Title = "Create brand";
+}
+
+<h2 class="esh-body-title">Create</h2>
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 form-horizontal">
+                @Html.ValidationSummary(true, "", new { @class = "text-danger" })
+                <div class="form-group">
+                    @Html.LabelFor(model => model.Brand, htmlAttributes: new { @class = "control-label col-md-2" })
+                    <div class="col-md-8">
+                        @Html.EditorFor(model => model.Brand, new { htmlAttributes = new { @class = "form-control" } })
+                        @Html.ValidationMessageFor(model => model.Brand, "", new { @class = "text-danger" })
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="col-md-offset-2 col-md-8 text-right esh-button-actions">
+                        @Html.ActionLink("[ Cancel ]", "Index", null, new { @class = "btn esh-button esh-button-secondary" })
+                        <input type="submit" value="[ Create ]" class="btn esh-button esh-button-primary" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@section Scripts {
+    <script src="~/js/jquery.validate.min.js"></script>
+    <script src="~/js/jquery.validate.unobtrusive.min.js"></script>
+}

--- a/eShopModernized/src/eShopCoreModernized/Views/Brands/Delete.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Brands/Delete.cshtml
@@ -1,0 +1,42 @@
+@model eShopCoreModernized.Models.CatalogBrand
+
+@{
+    ViewBag.Title = "Delete brand";
+}
+
+<h2 class="esh-body-title">Delete</h2>
+
+<div class="container">
+    <h3>Are you sure you want to delete this?</h3>
+    @Html.ValidationSummary(false, "", new { @class = "text-danger" })
+
+    @if (ViewBag.IsBrandInUse == true)
+    {
+        <p class="text-danger">Catalog items still reference this brand, so it cannot be deleted.</p>
+    }
+
+    <dl class="col-md-6 dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+
+        <dt>
+            @Html.DisplayNameFor(model => model.Brand)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Brand)
+        </dd>
+
+        <dd class="esh-button-actions">
+            @using (Html.BeginForm())
+            {
+                @Html.AntiForgeryToken()
+                @Html.ActionLink("[ Cancel ]", "Index", null, new { @class = "btn esh-button esh-button-secondary" })
+                <button type="submit" class="btn esh-button esh-button-primary" disabled="@(ViewBag.IsBrandInUse == true)">[ Delete ]</button>
+            }
+        </dd>
+    </dl>
+</div>

--- a/eShopModernized/src/eShopCoreModernized/Views/Brands/Details.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Brands/Details.cshtml
@@ -1,0 +1,30 @@
+@model eShopCoreModernized.Models.CatalogBrand
+
+@{
+    ViewBag.Title = "Brand details";
+}
+
+<h2 class="esh-body-title">Details</h2>
+
+<div class="container">
+    <dl class="col-md-6 dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+
+        <dt>
+            @Html.DisplayNameFor(model => model.Brand)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Brand)
+        </dd>
+
+        <dd class="esh-button-actions">
+            @Html.ActionLink("[ Back ]", "Index", null, new { @class = "btn esh-button esh-button-secondary" })
+            @Html.ActionLink("[ Edit ]", "Edit", new { id = Model.Id }, new { @class = "btn esh-button esh-button-primary" })
+        </dd>
+    </dl>
+</div>

--- a/eShopModernized/src/eShopCoreModernized/Views/Brands/Edit.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Brands/Edit.cshtml
@@ -1,0 +1,39 @@
+@model eShopCoreModernized.Models.CatalogBrand
+
+@{
+    ViewBag.Title = "Edit brand";
+}
+
+<h2 class="esh-body-title">Edit</h2>
+
+@using (Html.BeginForm())
+{
+    @Html.AntiForgeryToken()
+    @Html.HiddenFor(model => model.Id)
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 form-horizontal">
+                @Html.ValidationSummary(true, "", new { @class = "text-danger" })
+                <div class="form-group">
+                    @Html.LabelFor(model => model.Brand, htmlAttributes: new { @class = "control-label col-md-2" })
+                    <div class="col-md-8">
+                        @Html.EditorFor(model => model.Brand, new { htmlAttributes = new { @class = "form-control" } })
+                        @Html.ValidationMessageFor(model => model.Brand, "", new { @class = "text-danger" })
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="col-md-offset-2 col-md-8 text-right esh-button-actions">
+                        @Html.ActionLink("[ Cancel ]", "Index", null, new { @class = "btn esh-button esh-button-secondary" })
+                        <input type="submit" value="[ Save ]" class="btn esh-button esh-button-primary" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@section Scripts {
+    <script src="~/js/jquery.validate.min.js"></script>
+    <script src="~/js/jquery.validate.unobtrusive.min.js"></script>
+}

--- a/eShopModernized/src/eShopCoreModernized/Views/Brands/Index.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Brands/Index.cshtml
@@ -1,0 +1,44 @@
+@model IEnumerable<eShopCoreModernized.Models.CatalogBrand>
+
+@{
+    ViewBag.Title = "Brands";
+}
+
+<div class="esh-table">
+    <p class="esh-link-wrapper">
+        @Html.ActionLink("Create New", "Create", null, new { @class = "btn esh-button esh-button-primary" })
+        @Html.ActionLink("[ Catalog ]", "Index", "Catalog", null, new { @class = "btn esh-button esh-button-secondary" })
+    </p>
+
+    <table class="table">
+        <thead>
+            <tr class="esh-table-header">
+                <th>
+                    @Html.DisplayNameFor(model => model.Id)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Brand)
+                </th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var brand in Model)
+            {
+                <tr>
+                    <td>
+                        @Html.DisplayFor(modelItem => brand.Id)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => brand.Brand)
+                    </td>
+                    <td>
+                        @Html.ActionLink("Edit", "Edit", new { id = brand.Id }, new { @class = "esh-table-link" }) |
+                        @Html.ActionLink("Details", "Details", new { id = brand.Id }, new { @class = "esh-table-link" }) |
+                        @Html.ActionLink("Delete", "Delete", new { id = brand.Id }, new { @class = "esh-table-link" })
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/eShopModernized/src/eShopCoreModernized/Views/Shared/_Layout.cshtml
+++ b/eShopModernized/src/eShopCoreModernized/Views/Shared/_Layout.cshtml
@@ -25,6 +25,10 @@
     <section class="esh-app-hero">
         <div class="container esh-header">
             <h1 class="esh-header-title">Catalog Manager<span>(MVC)</span></h1>
+            <nav class="esh-header-nav">
+                <a class="esh-table-link" href="@Url.Action("index", "catalog")">Catalog</a>
+                <a class="esh-table-link" href="@Url.Action("index", "brands")">Brands</a>
+            </nav>
         </div>
     </section>
 

--- a/eShopModernized/tests/eShopCoreModernized.Tests/BrandServiceTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/BrandServiceTests.cs
@@ -1,0 +1,114 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopCoreModernized.Tests
+{
+    public class BrandServiceTests
+    {
+        private sealed class StubBrandIdGenerator : IBrandIdGenerator
+        {
+            private int nextId;
+
+            public StubBrandIdGenerator(int firstId)
+            {
+                nextId = firstId;
+            }
+
+            public Task<int> GetNextSequenceValueAsync(CatalogDBContext db) => Task.FromResult(nextId++);
+        }
+
+        private static CatalogDBContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<CatalogDBContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            var db = new CatalogDBContext(options);
+            db.CatalogBrands.AddRange(
+                new CatalogBrand { Id = 2, Brand = ".NET" },
+                new CatalogBrand { Id = 1, Brand = "Azure" });
+            db.CatalogTypes.Add(new CatalogType { Id = 1, Type = "Mug" });
+            db.CatalogItems.Add(new CatalogItem
+            {
+                Id = 1,
+                Name = ".NET Black & White Mug",
+                Price = 8.5M,
+                CatalogBrandId = 2,
+                CatalogTypeId = 1
+            });
+            db.SaveChanges();
+
+            return db;
+        }
+
+        [Fact]
+        public async Task GetBrandsAsync_returns_brands_ordered_by_id()
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+
+            var brands = (await service.GetBrandsAsync()).ToList();
+
+            Assert.Equal(new[] { 1, 2 }, brands.Select(b => b.Id));
+        }
+
+        [Fact]
+        public async Task FindBrandAsync_returns_null_for_unknown_id()
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+
+            Assert.Null(await service.FindBrandAsync(999));
+        }
+
+        [Fact]
+        public async Task CreateBrandAsync_assigns_id_from_the_sequence_generator()
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+            var brand = new CatalogBrand { Brand = "Contoso" };
+
+            await service.CreateBrandAsync(brand);
+
+            Assert.Equal(100, brand.Id);
+            Assert.Equal("Contoso", (await db.CatalogBrands.SingleAsync(b => b.Id == 100)).Brand);
+        }
+
+        [Fact]
+        public async Task UpdateBrandAsync_persists_the_new_name()
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+
+            var brand = await service.FindBrandAsync(1);
+            brand!.Brand = "Azure Cloud";
+            await service.UpdateBrandAsync(brand);
+
+            Assert.Equal("Azure Cloud", (await db.CatalogBrands.SingleAsync(b => b.Id == 1)).Brand);
+        }
+
+        [Fact]
+        public async Task RemoveBrandAsync_deletes_the_brand()
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+
+            var brand = await service.FindBrandAsync(1);
+            await service.RemoveBrandAsync(brand!);
+
+            Assert.False(await db.CatalogBrands.AnyAsync(b => b.Id == 1));
+        }
+
+        [Theory]
+        [InlineData(2, true)]
+        [InlineData(1, false)]
+        public async Task IsBrandInUseAsync_reports_whether_catalog_items_reference_the_brand(int brandId, bool expected)
+        {
+            using var db = CreateContext();
+            var service = new BrandService(db, new StubBrandIdGenerator(100));
+
+            Assert.Equal(expected, await service.IsBrandInUseAsync(brandId));
+        }
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/BrandsApiControllerTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/BrandsApiControllerTests.cs
@@ -1,0 +1,89 @@
+using eShopCoreModernized.Controllers.Api;
+using eShopCoreModernized.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace eShopCoreModernized.Tests
+{
+    public class BrandsApiControllerTests
+    {
+        private static BrandsApiController CreateController(FakeBrandService service) =>
+            new BrandsApiController(service, NullLogger<BrandsApiController>.Instance);
+
+        [Fact]
+        public async Task Get_returns_every_brand()
+        {
+            var controller = CreateController(new FakeBrandService());
+
+            var result = await controller.Get();
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(2, Assert.IsAssignableFrom<IEnumerable<CatalogBrand>>(ok.Value).Count());
+        }
+
+        [Fact]
+        public async Task Get_by_id_returns_not_found_for_unknown_brand()
+        {
+            var controller = CreateController(new FakeBrandService());
+
+            Assert.IsType<NotFoundResult>((await controller.Get(999)).Result);
+        }
+
+        [Fact]
+        public async Task Post_creates_the_brand_and_returns_its_location()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.Post(new CatalogBrand { Brand = "Contoso" });
+
+            var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+            Assert.Equal(3, Assert.IsType<CatalogBrand>(created.Value).Id);
+            Assert.Contains(service.Brands, b => b.Brand == "Contoso");
+        }
+
+        [Fact]
+        public async Task Put_renames_the_brand()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.Put(1, new CatalogBrand { Id = 1, Brand = "Azure Cloud" });
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.Equal("Azure Cloud", service.Brands.Single(b => b.Id == 1).Brand);
+        }
+
+        [Fact]
+        public async Task Put_returns_not_found_for_unknown_brand()
+        {
+            var controller = CreateController(new FakeBrandService());
+
+            Assert.IsType<NotFoundResult>(await controller.Put(999, new CatalogBrand { Brand = "Nope" }));
+        }
+
+        [Fact]
+        public async Task Delete_removes_an_unreferenced_brand()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.Delete(1);
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.DoesNotContain(service.Brands, b => b.Id == 1);
+        }
+
+        [Fact]
+        public async Task Delete_conflicts_when_catalog_items_still_reference_the_brand()
+        {
+            var service = new FakeBrandService(inUse: new[] { 1 });
+            var controller = CreateController(service);
+
+            var result = await controller.Delete(1);
+
+            Assert.IsType<ConflictObjectResult>(result);
+            Assert.Contains(service.Brands, b => b.Id == 1);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/BrandsControllerTests.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/BrandsControllerTests.cs
@@ -1,0 +1,93 @@
+using eShopCoreModernized.Controllers;
+using eShopCoreModernized.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace eShopCoreModernized.Tests
+{
+    public class BrandsControllerTests
+    {
+        private static BrandsController CreateController(FakeBrandService service) =>
+            new BrandsController(service, NullLogger<BrandsController>.Instance);
+
+        [Fact]
+        public async Task Index_shows_every_brand()
+        {
+            var controller = CreateController(new FakeBrandService());
+
+            var view = Assert.IsType<ViewResult>(await controller.Index());
+
+            var model = Assert.IsAssignableFrom<IEnumerable<CatalogBrand>>(view.Model);
+            Assert.Equal(2, model.Count());
+        }
+
+        [Fact]
+        public async Task Details_returns_not_found_for_unknown_brand()
+        {
+            var controller = CreateController(new FakeBrandService());
+
+            Assert.IsType<NotFoundResult>(await controller.Details(999));
+        }
+
+        [Fact]
+        public async Task Create_redirects_to_index_and_persists_the_brand()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.Create(new CatalogBrand { Brand = "Contoso" });
+
+            var redirect = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(nameof(BrandsController.Index), redirect.ActionName);
+            Assert.Contains(service.Brands, b => b.Brand == "Contoso");
+        }
+
+        [Fact]
+        public async Task Create_redisplays_the_form_when_the_model_is_invalid()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+            controller.ModelState.AddModelError(nameof(CatalogBrand.Brand), "Required");
+
+            Assert.IsType<ViewResult>(await controller.Create(new CatalogBrand()));
+            Assert.Equal(2, service.Brands.Count);
+        }
+
+        [Fact]
+        public async Task Edit_renames_the_existing_brand()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.Edit(new CatalogBrand { Id = 1, Brand = "Azure Cloud" });
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Azure Cloud", service.Brands.Single(b => b.Id == 1).Brand);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_removes_an_unreferenced_brand()
+        {
+            var service = new FakeBrandService();
+            var controller = CreateController(service);
+
+            var result = await controller.DeleteConfirmed(1);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.DoesNotContain(service.Brands, b => b.Id == 1);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_keeps_a_brand_that_catalog_items_still_reference()
+        {
+            var service = new FakeBrandService(inUse: new[] { 1 });
+            var controller = CreateController(service);
+
+            var result = await controller.DeleteConfirmed(1);
+
+            Assert.IsType<ViewResult>(result);
+            Assert.False(controller.ModelState.IsValid);
+            Assert.Contains(service.Brands, b => b.Id == 1);
+        }
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/FakeBrandService.cs
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/FakeBrandService.cs
@@ -1,0 +1,51 @@
+using eShopCoreModernized.Models;
+using eShopCoreModernized.Services;
+
+namespace eShopCoreModernized.Tests
+{
+    internal sealed class FakeBrandService : IBrandService
+    {
+        private readonly List<CatalogBrand> brands;
+        private readonly HashSet<int> brandsInUse;
+
+        public FakeBrandService(IEnumerable<CatalogBrand>? seed = null, IEnumerable<int>? inUse = null)
+        {
+            brands = seed?.ToList() ?? new List<CatalogBrand>
+            {
+                new CatalogBrand { Id = 1, Brand = "Azure" },
+                new CatalogBrand { Id = 2, Brand = ".NET" }
+            };
+            brandsInUse = new HashSet<int>(inUse ?? Enumerable.Empty<int>());
+        }
+
+        public Task<IEnumerable<CatalogBrand>> GetBrandsAsync() =>
+            Task.FromResult<IEnumerable<CatalogBrand>>(brands.OrderBy(b => b.Id).ToList());
+
+        public Task<CatalogBrand?> FindBrandAsync(int id) =>
+            Task.FromResult(brands.FirstOrDefault(b => b.Id == id));
+
+        public Task CreateBrandAsync(CatalogBrand brand)
+        {
+            brand.Id = brands.Count == 0 ? 1 : brands.Max(b => b.Id) + 1;
+            brands.Add(brand);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateBrandAsync(CatalogBrand brand)
+        {
+            var existing = brands.Single(b => b.Id == brand.Id);
+            existing.Brand = brand.Brand;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveBrandAsync(CatalogBrand brand)
+        {
+            brands.RemoveAll(b => b.Id == brand.Id);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsBrandInUseAsync(int id) => Task.FromResult(brandsInUse.Contains(id));
+
+        public IReadOnlyList<CatalogBrand> Brands => brands;
+    }
+}

--- a/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
+++ b/eShopModernized/tests/eShopCoreModernized.Tests/eShopCoreModernized.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\eShopCoreModernized\eShopModernized.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Strangler-fig step: catalog **brand reference data** now has a full write path in the modern .NET 8 app (`eShopCoreModernized`), so brand management can be routed away from `eShopLegacyMVC` at the proxy. Before this change the modern app could only *read* brands (`GET api/Brands`, with a `DELETE` that returned `200 OK` without deleting anything); brand rows were only ever created by the legacy EF6 `CatalogDBInitializer` seeding.

Legacy → modern mapping for the slice:

| eShopLegacyMVC (.NET Framework 4.7.2, EF6) | eShopCoreModernized (.NET 8, EF Core 8) |
| --- | --- |
| `Controllers/WebApi/BrandsController` (read-only ApiController) | `Controllers/Api/BrandsApiController` — `GET`/`GET{id}`/`POST`/`PUT`/`DELETE` at the same `api/brands` routes |
| — (no brand UI; brands only editable via DB) | `Controllers/BrandsController` + `Views/Brands/*` MVC CRUD, `[Authorize]` on writes like `CatalogController` |
| `ICatalogService.GetCatalogBrands` (EF6 `CatalogDBContext`) | `IBrandService` / `BrandService` (EF Core), `BrandServiceMock` for `UseMockData` |
| `catalog_brand_hilo` sequence read by `CatalogDBInitializer` | `CatalogBrandHiLoGenerator : IBrandIdGenerator` (`SELECT NEXT VALUE FOR catalog_brand_hilo`), mirroring `CatalogItemHiLoGenerator` |
| `Catalog.CatalogBrandId` FK | `IsBrandInUseAsync` guard → `409 Conflict` (API) / re-rendered delete view with model error (MVC) |

The read API surface is unchanged (`api/brands` still returns the same payload); the class was renamed to `BrandsApiController` so the MVC controller can own `/Brands` and `Views/Brands`. The mock provider deliberately mutates the live list handed out by `CatalogServiceMock`, so brands created in mock mode still appear in the catalog item dropdowns.

Target framework was already `net8.0`, so no retarget was needed.

## Test evidence

- Legacy baseline (Windows-only) still builds after the change:
  `msbuild eShopLegacyMVCSolution\eShopLegacyMVC.sln /p:Configuration=Debug` → `eShopLegacyMVC.dll`, `eShopLegacy.Utilities.dll`, `eShopPorted.exe` all built, 0 errors. Requires VS 2022 Build Tools + .NET Framework 4.6.1/4.7.2 dev packs and `nuget restore`; no legacy file was touched.
- Modern app: `dotnet build` → 0 errors, and a new `eShopModernized/tests/eShopCoreModernized.Tests` xUnit project (added to a new `eShopModernized.sln`) → **21 passed / 0 failed**, covering `BrandService` against EF Core InMemory (sequence-assigned ids, in-use detection) and both controllers (validation, not-found, conflict-on-delete).

## Recommended next slice

Catalog **types** (`CatalogType` + `catalog_type_hilo`): identical shape to this slice and the last piece of reference data the legacy app still owns, after which the legacy `CatalogDBInitializer`/`PreconfiguredData` seeding can be ported and the legacy MVC app can be taken out of the write path for everything except catalog item pictures.

Link to Devin session: https://app.devin.ai/sessions/fe91835fda084aa384dd99a8faa4471d
Requested by: @achalc
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/60?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/eShopModernizing/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->